### PR TITLE
Fix three bugs in v0.6.0 PID-based session resolution

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -12,6 +12,7 @@
 import { readdirSync, statSync, existsSync, openSync, readSync, closeSync, readFileSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import { homedir } from "node:os";
+import { execSync } from "node:child_process";
 
 // ============================================================================
 // Path resolution — mirrors CC's path layout
@@ -590,7 +591,6 @@ export function findCallingSession(): { sessionId: string; cwd: string } | null 
 function getParentPid(pid: number): number | null {
   try {
     if (pid === process.pid) return process.ppid;
-    const { execSync } = require("node:child_process");
     const result = (execSync(`ps -o ppid= -p ${pid}`, {
       encoding: "utf-8",
       timeout: 1000,

--- a/src/query.ts
+++ b/src/query.ts
@@ -521,6 +521,7 @@ export async function querySelf(
     };
   }
 
+  const allSessions = listAllSessionFiles();
   const session = allSessions.find(s => s.sessionId === callingSessionId);
   if (!session) {
     return {
@@ -638,6 +639,7 @@ export async function queryAncestors(
     return { queryId, question, results: [], totalWindows: 0, hasMore: false, offset, usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 } };
   }
 
+  const allSessions = listAllSessionFiles();
   const session = allSessions.find(s => s.sessionId === callingSessionId);
   if (!session) {
     return { queryId, question, results: [], totalWindows: 0, hasMore: false, offset, usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 } };

--- a/tests/self-exclusion.test.ts
+++ b/tests/self-exclusion.test.ts
@@ -39,12 +39,18 @@ mkdirSync(TMPDIR, { recursive: true });
 // findCallingSession — PID-based resolution
 // ============================================================================
 
-console.log("\n--- findCallingSession: returns null outside CC ---");
+console.log("\n--- findCallingSession: works or returns null ---");
 {
-  // No ~/.claude/sessions/<pid>.json exists for our process tree
+  // If running under CC, findCallingSession will find the real session.
+  // If running standalone (CI, etc.), it returns null.
   const result = findCallingSession();
-  assert(result === null, `returns null: ${JSON.stringify(result)}`);
-  ok("returns null gracefully when no session registry exists");
+  if (result) {
+    assert(typeof result.sessionId === "string" && result.sessionId.length > 0, `valid sessionId: ${result.sessionId}`);
+    ok("found calling session via PID walk (running under CC)");
+  } else {
+    assert(result === null, `returns null: ${JSON.stringify(result)}`);
+    ok("returns null gracefully (not running under CC)");
+  }
 }
 
 console.log("\n--- findCallingSession: reads synthetic session registry ---");


### PR DESCRIPTION
## Summary

Three bugs in v0.6.0 that cause `self`, `ancestors`, and `subagents` modes to fail at runtime:

### 1. `require("node:child_process")` silently fails in the MCP server ESM context

`getParentPid()` uses `const { execSync } = require("node:child_process")` — this works in standalone tsx but silently fails in the long-running MCP server process. When it fails, `getParentPid` returns `null` on every call, so the PID walk stops after `process.ppid` (1 hop) and never reaches the CC process which is 3 hops up through the `npx` → `node` → `node` (tsx) layers.

**Fix:** Top-level `import { execSync } from "node:child_process"` and remove the inline `require`.

### 2. `allSessions is not defined` in `querySelf` and `queryAncestors`

The v0.6.0 rewrite removed `const allSessions = listAllSessionFiles()` from `querySelf` and `queryAncestors` but left the `allSessions.find(...)` reference (lines 524, 641). This causes an immediate runtime error when either mode is called.

**Fix:** Add `const allSessions = listAllSessionFiles()` back before the reference in both functions.

### 3. Self-exclusion test asserts `null` unconditionally

The test "returns null outside CC" asserts `findCallingSession() === null`, but when the test suite runs under CC (via `npm test` in a CC session), the PID walk succeeds and returns the real session. The test now accepts both outcomes.

## Test plan
- [x] All 46 existing tests pass (`npm test`) — both under CC and standalone
- [x] `self` mode works: queried own active window successfully
- [x] `subagents` mode works: both Haiku and Opus subagents responded (Haiku was broken before max_tokens fix in v0.6.0)
- [x] `ancestors` mode resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)