### PR TITLE
Fall back to calling session cwd for project/branch routing

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -20,7 +20,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { processSessionFile, processSessionWindows } from "./pipeline.js";
-import { resolveSessionFiles, getProjectsDir, listAllSessionFiles, listProjects, extractGitBranch, extractSessionPreview, cwdToProjectDirName } from "./discovery.js";
+import { resolveSessionFiles, getProjectsDir, listAllSessionFiles, listProjects, extractGitBranch, extractSessionPreview, cwdToProjectDirName, findCallingSession } from "./discovery.js";
 import { querySingleWindow, queryBatch, querySelf, queryAncestors, querySubagents } from "./query.js";
 
 // ============================================================================
@@ -351,7 +351,7 @@ async function handleDuncanQuery(args: {
         mode: args.mode as any,
         projectDir: args.projectDir,
         sessionId: args.sessionId,
-        cwd: args.cwd,
+        cwd: args.cwd ?? findCallingSession()?.cwd,
         limit: args.limit ?? 10,
         offset: args.offset ?? 0,
         includeSubagents: args.includeSubagents ?? false,


### PR DESCRIPTION
## Summary

- Project and branch modes returned "No sessions found" when `cwd` wasn't explicitly passed, because `resolveSessionFiles` had no cwd to map to a project directory.
- The calling session's cwd (from the PID-based registry at `~/.claude/sessions/<pid>.json`) is the obvious default — self/ancestors/subagents already resolve it implicitly. One-line fix: `cwd: args.cwd ?? findCallingSession()?.cwd`.

## Test plan

- [x] All existing tests pass
- [ ] Live test: `duncan_query` with `mode: "project"` and no `cwd` param returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)