### PR TITLE
Apply calling session cwd fallback to duncan_list_sessions

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -463,7 +463,7 @@ async function handleListSessions(args: {
     const resolved = resolveSessionFiles({
       mode: args.mode as any,
       projectDir,
-      cwd: args.cwd,
+      cwd: args.cwd ?? findCallingSession()?.cwd,
       limit: args.limit ?? 20,
     });
 


### PR DESCRIPTION
## Summary

- Same issue as #9: `duncan_list_sessions` in project mode returned "No sessions found" when no explicit `cwd` was passed.
- Same one-line fix: `cwd: args.cwd ?? findCallingSession()?.cwd`

## Test plan

- [x] All existing tests pass
- [x] Live test: `duncan_list_sessions` with `mode: "project"` and no `cwd` returns sessions
- [x] Explicit `cwd` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)