### PR TITLE
cut over duncan-cc to ephemeral headless Claude

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,10 +2,18 @@
 
 ## Overview
 
-Duncan-cc replicates CC's full message pipeline to hydrate dormant CC sessions,
-then queries them with questions via the Anthropic API. Exposed as an MCP server
-(stdio transport) with three tools: `duncan_query`, `duncan_projects`, and
-`duncan_list_sessions`.
+Duncan-cc currently replicates CC's full message pipeline to hydrate dormant CC
+sessions, then queries them with questions via the Anthropic API. Exposed as an
+MCP server (stdio transport) with three tools: `duncan_query`,
+`duncan_projects`, and `duncan_list_sessions`.
+
+The rewrite in progress adds a second execution backend:
+- `api` — current direct Anthropic API path
+- `headless` — staged transcript + real `claude --print --resume <jsonl>` path
+
+Short-term goal: land the headless backend beside the current backend, prove it
+works well enough, then decide whether it should replace the reverse-engineered
+API/OAuth path.
 
 ## Pipeline: Disk → API
 
@@ -172,6 +180,26 @@ For subagent transcripts, the system prompt is dispatched based on agent type
 Note: tool schemas are NOT included — duncan sends only its own `duncan_response`
 tool. The session's original tools are not callable during a duncan query.
 
+## Headless Backend Notes
+
+The headless backend stages transcript files and resumes them through real
+Claude Code. Current proven pieces:
+- staged transcript layout and raw-window slicing
+- compaction-window truncation contracts
+- real `claude --print --resume <jsonl>` invocation wrapper
+- real-Claude memory benchmarking at controlled concurrency
+
+Observed real-Claude memory profile on this 4 GB Linux machine, measuring only
+Claude child PIDs:
+- batch/concurrency `5` → peak aggregate RSS about **1.45 GB**
+- batch/concurrency `10` → peak aggregate RSS about **2.73 GB**
+
+Interpretation:
+- RSS scales roughly linearly with concurrency for this workload
+- virtual size is huge and noisy, but RSS is the meaningful capacity signal
+- `batchSize` must be treated as a memory knob for the headless backend, not
+  just a throughput knob
+
 ## Query Logging
 
 Every query is logged to `~/.claude/duncan.jsonl` as append-only JSONL. Each record:
@@ -235,7 +263,7 @@ Query dormant sessions. Parameters:
 - `offset`: pagination offset
 - `copies`: for self mode, number of samples (default: 3)
 - `includeSubagents`: include subagent transcripts (default: false)
-- `batchSize`: max concurrent API calls per batch (default: 5)
+- `batchSize`: max concurrent queries per batch (default: 5). Warning: for the headless real-Claude backend, memory use scales roughly linearly with `batchSize`; on this 4 GB test machine, `5` concurrent Claude subprocesses used about 1.45 GB RSS and `10` used about 2.73 GB RSS.
 - `gitBranch`: for branch mode, explicit branch name
 
 ### duncan_projects

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,12 +8,11 @@ MCP server (stdio transport) with three tools: `duncan_query`,
 `duncan_projects`, and `duncan_list_sessions`.
 
 The rewrite in progress adds a second execution backend:
-- `api` — current direct Anthropic API path
 - `headless` — staged transcript + real `claude --print --resume <jsonl>` path
+- `api` — prior direct Anthropic API path, kept only as a temporary fallback toggle on this branch
 
-Short-term goal: land the headless backend beside the current backend, prove it
-works well enough, then decide whether it should replace the reverse-engineered
-API/OAuth path.
+Branch default now points at the `headless` backend. The older API path remains
+available only as a fallback while the cutover is being hardened.
 
 ## Pipeline: Disk → API
 

--- a/benches/headless-fanout-real-claude.bench.ts
+++ b/benches/headless-fanout-real-claude.bench.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseJsonl } from "../src/parser.js";
+import { runFanout } from "../src/headless/fanout.js";
+import { sampleProcessSet } from "../src/headless/resource-sampler.js";
+import { deriveSessionWindowsFromEntries } from "../src/headless/session-boundaries.js";
+import { stageSession } from "../src/headless/session-stager.js";
+import { runClaudeHeadless } from "../src/headless/claude-runner.js";
+import { requireCorpus } from "../tests/_skip-if-no-corpus.js";
+
+function parseClaudeJson(stdout: string): any {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Failed to parse Claude JSON output: ${String(error)}\nSTDOUT:\n${stdout}`);
+  }
+}
+
+const corpus = requireCorpus();
+const sourceSessionFile = join(
+  corpus,
+  "-Users-wednesdayniemeyer--claude-skills-inspect-claude-source",
+  "28e532ae-cb50-4f6f-9f08-914cbf6563b7.jsonl",
+);
+const sourceProjectDir = join(corpus, "-Users-wednesdayniemeyer--claude-skills-inspect-claude-source");
+const sourceEntries = parseJsonl(await readFile(sourceSessionFile, "utf8"));
+const windows = deriveSessionWindowsFromEntries(sourceEntries);
+assert.ok(windows.length >= 1, "expected at least one stageable window");
+
+const prompt = "Reply with exactly: pong";
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-real-claude-fanout-"));
+const model = process.env.DUNCAN_CC_REAL_BENCH_MODEL ?? "sonnet";
+const concurrencySweep = (process.env.DUNCAN_CC_REAL_BENCH_CONCURRENCIES ?? "5")
+  .split(",")
+  .map((value) => Number(value.trim()))
+  .filter((value) => Number.isInteger(value) && value > 0);
+assert.ok(concurrencySweep.length > 0, "expected at least one valid concurrency value");
+const sweepResults: Array<Record<string, number | string | null>> = [];
+
+for (const concurrency of concurrencySweep) {
+  console.log(`running real Claude fanout benchmark at concurrency=${concurrency}`);
+  const targets = Array.from({ length: concurrency }, (_, i) => ({ id: `c${concurrency}-target-${i}` }));
+  const activePids = new Set<number>();
+  let finished = false;
+  const samplerPromise = sampleProcessSet(() => activePids, {
+    intervalMs: 10,
+    isDone: () => finished,
+  });
+
+  const result = await runFanout(targets, {
+    concurrency,
+    stageTarget: async (_target, index) => {
+      const stage = await stageSession({
+        sourceSessionFile,
+        sourceProjectDir,
+        stageRootDir: join(root, `c${concurrency}`),
+        stageProjectSlug: `project-${concurrency}`,
+        window: windows[0]!,
+        copyToolResults: false,
+        copySubagents: false,
+      });
+      const stagedStat = await stat(stage.stagedSessionFile);
+      return {
+        stage,
+        stagedBytes: stagedStat.size,
+        stageDirCount: 1,
+      };
+    },
+    runTarget: async (_target, stage, index) => {
+      const bench = await runClaudeHeadless({
+        cwd: stage.stageProjectDir,
+        resume: stage.stagedSessionFile,
+        prompt,
+        outputFormat: "json",
+        timeoutMs: 180000,
+        extraArgs: ["--model", model, "--tools", "", "--effort", "low"],
+        onSpawn: (pid) => activePids.add(pid),
+      });
+      if (bench.pid) activePids.delete(bench.pid);
+      assert.equal(bench.ok, true, `real claude run ${index} failed: ${bench.stderr || bench.stdout}`);
+      const parsed = parseClaudeJson(bench.stdout);
+      assert.equal(String(parsed.result).trim(), "pong", `unexpected result for concurrency ${concurrency}: ${parsed.result}`);
+      return {
+        ok: true,
+        durationMs: bench.durationMs,
+        totalCostUsd: typeof parsed.total_cost_usd === "number" ? parsed.total_cost_usd : null,
+        inputTokens: parsed.usage?.input_tokens ?? null,
+        outputTokens: parsed.usage?.output_tokens ?? null,
+      };
+    },
+  });
+
+  finished = true;
+  const sample = await samplerPromise;
+  const totalCostUsd = result.results.reduce((sum, entry) => sum + (typeof entry.totalCostUsd === "number" ? entry.totalCostUsd : 0), 0);
+  const maxDurationMs = result.results.reduce((max, entry) => Math.max(max, entry.durationMs), 0);
+
+  assert.equal(result.metrics.targetCount, concurrency);
+  assert.equal(result.metrics.spawnCount, concurrency);
+  assert.ok(sample.maxObservedProcessCount <= concurrency, `observed ${sample.maxObservedProcessCount} active Claude subprocesses with cap ${concurrency}`);
+  if (sample.peakAggregateRssBytes !== undefined) {
+    assert.ok(sample.peakAggregateRssBytes > 0);
+  }
+  if (sample.peakAggregateVirtualBytes !== undefined) {
+    assert.ok(sample.peakAggregateVirtualBytes > 0);
+  }
+
+  sweepResults.push({
+    concurrency,
+    model,
+    wallTimeMs: result.metrics.wallTimeMs,
+    maxSingleRunMs: maxDurationMs,
+    peakProcesses: sample.maxObservedProcessCount,
+    peakRssBytes: sample.peakAggregateRssBytes ?? null,
+    peakVirtualBytes: sample.peakAggregateVirtualBytes ?? null,
+    totalStagedBytes: result.metrics.totalStagedBytes,
+    totalCostUsd: Number(totalCostUsd.toFixed(6)),
+  });
+}
+
+console.log("headless-fanout-real-claude.bench.ts: ok", JSON.stringify(sweepResults));

--- a/docs/ephemeral-headless-rewrite.md
+++ b/docs/ephemeral-headless-rewrite.md
@@ -75,6 +75,22 @@ Assessment:
 - That makes it a mismatch for the rewrite goal: use real headless Claude Code with its normal auth/session machinery instead of replacing it with another custom auth path.
 - Keep `--bare` only as a possible lab/debug curiosity if we ever want a hermetic API-key benchmark, but it should be treated as **out of scope for the actual rewrite path**.
 
+### 1c. Why session-id rewriting remains optional instead of default
+
+Findings from the staging spike:
+- default transcript mutation was the first thing that broke exact raw-window preservation tests
+- preserving raw JSONL entries is the safest default if the goal is "resume what Claude already wrote"
+- the staged file path and staged directory layout already give us isolation, even when the transcript's internal session id stays unchanged
+
+Why keep the rewrite path at all:
+- as an escape hatch if Claude resume behavior later proves sensitive to session-id collisions when multiple staged copies coexist
+- for experiments that intentionally want a fresh synthetic identity, closer to Claude's own branch/fork behavior
+- for cases where staged sidecars/subagents/tool-results need to be forced under a fresh session namespace
+
+Recommendation:
+- default = preserve raw entries
+- optional rewrite = explicit experiment knob, not baseline behavior
+
 ### 2. Cross-directory resume from a raw JSONL path is explicitly supported
 
 Relevant source:
@@ -310,10 +326,20 @@ Tests/benchmarks should measure:
 - wall clock at configurable concurrency
 - average/median staging latency
 - average/median subprocess latency
+- process memory envelope at concurrency sweeps like `1`, `5`, `10`, `20`
+  - rss when available
+  - virtual size / vsize / vsz when available
+  - temp-disk usage across staged dirs
 
 This spike does **not** need real Claude model calls in CI. A fake runner is
 acceptable for deterministic resource tests, as long as the real runner contract
 is the same.
+
+Recommended benchmark shape:
+- run a concurrency sweep at `1`, `5`, `10`, and `20`
+- measure both controller-process memory and child-process memory where possible
+- on Linux, prefer `/proc/<pid>/status` or `ps` sampling for VmRSS / VmSize
+- treat virtual memory as useful but secondary; rss is the more important signal
 
 ---
 
@@ -417,10 +443,18 @@ Concrete findings:
 - compaction-window staging works best as exact raw-entry slicing from `compact_boundary` to the next boundary/end
 - a simple 20-target fanout harness is operationally cheap enough to keep iterating locally, with concurrency caps enforced in-process
 - a minimal `claude --print --resume <jsonl>` runner wrapper is straightforward; the remaining uncertainty is not invocation shape but fidelity of staged filesystem context
+- concurrency-sweep resource benchmark now exists for `1`, `5`, `10`, `20` concurrent child processes using real spawned processes plus staged temp files
+- observed Linux memory profile in the synthetic benchmark was roughly:
+  - `1` concurrent: ~48 MB peak aggregate RSS, ~500 MB peak aggregate virtual size
+  - `5` concurrent: ~233 MB peak aggregate RSS, ~2.5 GB peak aggregate virtual size
+  - `10` concurrent: ~463 MB peak aggregate RSS, ~5.0 GB peak aggregate virtual size
+  - `20` concurrent: ~0.8–0.86 GB peak aggregate RSS, ~9.0–10.0 GB peak aggregate virtual size
+- interpretation: virtual size balloons much faster than RSS in this Node-based synthetic harness, so RSS is the more useful capacity signal; the virtual numbers are still worth watching for address-space / mapping weirdness
 
 Latest validation on this branch:
 - full `npm test` suite: **passing**
 - headless spike tests: **passing**
+- concurrency-sweep memory benchmark: **passing**
 
 ## Current Recommendation
 

--- a/docs/ephemeral-headless-rewrite.md
+++ b/docs/ephemeral-headless-rewrite.md
@@ -137,6 +137,8 @@ Current fidelity strategy on this branch:
 - prefer running Claude with the transcript's original `cwd` when that directory still exists, so normal `CLAUDE.md` auto-discovery and live project context resolution keep working
 - fall back to the staged temp project dir only when the original `cwd` is unavailable
 - memory/CLAUDE.md are therefore currently handled by **original-cwd execution**, not by copying those files into the stage dir
+- headless Claude runs now pass `--no-session-persistence` by default so the subprocess does not create durable Claude transcripts of the derivative staged session
+- `--fork-session` is not used by default because the current goal is ephemeral execution without persistence, not creation of a new durable resumed session lineage
 
 ### 4. Compaction boundaries are real transcript boundaries, not just logical markers
 

--- a/docs/ephemeral-headless-rewrite.md
+++ b/docs/ephemeral-headless-rewrite.md
@@ -449,20 +449,30 @@ Concrete findings:
   - `5` concurrent: ~233 MB peak aggregate RSS, ~2.5 GB peak aggregate virtual size
   - `10` concurrent: ~463 MB peak aggregate RSS, ~5.0 GB peak aggregate virtual size
   - `20` concurrent: ~0.8–0.86 GB peak aggregate RSS, ~9.0–10.0 GB peak aggregate virtual size
-- interpretation: virtual size balloons much faster than RSS in this Node-based synthetic harness, so RSS is the more useful capacity signal; the virtual numbers are still worth watching for address-space / mapping weirdness
+- real-Claude subprocess measurements were then run against staged transcripts, counting only Claude child PIDs:
+  - `5` concurrent: ~1.45 GB peak aggregate RSS, ~382.7 GB peak aggregate virtual size, ~15.4 s wall time
+  - `10` concurrent: ~2.73 GB peak aggregate RSS, ~765.6 GB peak aggregate virtual size, ~26.1 s wall time
+- interpretation: real-Claude RSS also scales roughly linearly with concurrency on this workload, making `batchSize` a real memory-capacity knob for the headless backend rather than just a throughput knob
+- practical consequence on this 4 GB box: `5` concurrent is workable, `10` is tight, and `20` should be treated as unsafe until proven on a roomier machine
 
 Latest validation on this branch:
 - full `npm test` suite: **passing**
 - headless spike tests: **passing**
 - concurrency-sweep memory benchmark: **passing**
 
+Operational note:
+- the real-Claude fanout benchmark should stay **out of the default `npm test` path**
+- run it explicitly via `npm run bench:real-claude-fanout`
+- set `DUNCAN_CC_REAL_BENCH_CONCURRENCIES=5` or `10` (and only later `20` if the machine can take it)
+
 ## Current Recommendation
 
-Do **not** jump straight to a full rewrite.
+Do **not** jump straight to deleting the old path.
 
-First prove, in order:
-1. staged-session correctness
-2. compaction-boundary truncation correctness
-3. 20-way fanout overhead
-
-Then wire the real headless runner behind those contracts.
+Next implementation sequence:
+1. keep the existing API backend intact
+2. add an explicit backend selector (`api` vs `headless`)
+3. wire single-window headless execution first
+4. propagate that backend through batch/self/ancestor query flows
+5. keep warning users that higher `batchSize` values in headless mode require materially more memory
+6. only consider full replacement after correctness and operating-cost confidence are both high

--- a/docs/ephemeral-headless-rewrite.md
+++ b/docs/ephemeral-headless-rewrite.md
@@ -1,0 +1,434 @@
+# Ephemeral Headless Rewrite — Research + Architecture
+
+branch: `duncan-cc-ephemeral-headless`
+
+## Goal
+
+Replace the current reverse-engineered dormant-session query path with an
+**ephemeral headless Claude Code** execution path that stages session files on
+disk, resumes them via the public CLI, and asks Duncan questions through the
+real Claude Code runtime.
+
+This rewrite is motivated by the likelihood that the OAuth path currently used
+by `duncan-cc` will become unavailable or too brittle to rely on.
+
+---
+
+## Source Research Findings
+
+### 1. Claude Code headless mode is the right execution surface
+
+Relevant source:
+- `claude-code-source/src/main.tsx`
+- `claude-code-source/src/cli/print.ts`
+
+Findings:
+- Claude Code has a supported non-interactive mode via `-p` / `--print`.
+- `--print` supports `--resume <session-id>`.
+- In print mode, resume also accepts a **`.jsonl` transcript path**.
+- `--output-format` supports `text`, `json`, and `stream-json`.
+- `--resume-session-at <message id>` exists, but it narrows the resumed
+  message list after loading; it is not a substitute for staging/truncating raw
+  transcript files at compaction boundaries.
+
+Implication:
+- The cleanest rewrite path is: **prepare a staged transcript file**, then run
+  `claude --print --resume <staged.jsonl>` in an isolated workspace.
+
+### 1b. `--bare` exists in current Claude Code and is potentially useful
+
+Relevant source:
+- installed `claude --help`
+- `claude-code-source/src/main.tsx`
+- `claude-code-source/src/entrypoints/cli.tsx`
+- `claude-code-source/src/utils/auth.ts`
+- `claude-code-source/src/context.ts`
+- `claude-code-source/src/setup.ts`
+- `claude-code-source/src/skills/loadSkillsDir.ts`
+- `claude-code-source/src/cli/print.ts`
+
+Findings:
+- Current Claude Code exposes `--bare` publicly in `--help`.
+- `--bare` sets `CLAUDE_CODE_SIMPLE=1` very early.
+- It skips a lot of ambient behavior:
+  - hooks
+  - LSP
+  - plugin sync / marketplace auto-load
+  - auto-memory
+  - background prefetches
+  - keychain / OAuth discovery
+  - CLAUDE.md auto-discovery
+  - most auto-discovered MCP config
+- It still allows **explicit** context/config surfaces, including:
+  - `--system-prompt`
+  - `--append-system-prompt`
+  - `--add-dir`
+  - `--mcp-config`
+  - `--settings`
+  - `--agents`
+  - `--plugin-dir`
+- Anthropic auth under `--bare` is API-key-oriented / hermetic rather than OAuth-driven.
+
+Assessment:
+- `--bare` is **not a viable production path** for this rewrite if we want to rely on Claude Code's normal OAuth-backed auth flow.
+- Source/help text explicitly say `--bare` disables OAuth/keychain auth and switches Anthropic auth to API-key/helper-only behavior.
+- That makes it a mismatch for the rewrite goal: use real headless Claude Code with its normal auth/session machinery instead of replacing it with another custom auth path.
+- Keep `--bare` only as a possible lab/debug curiosity if we ever want a hermetic API-key benchmark, but it should be treated as **out of scope for the actual rewrite path**.
+
+### 2. Cross-directory resume from a raw JSONL path is explicitly supported
+
+Relevant source:
+- `claude-code-source/src/utils/conversationRecovery.ts`
+- `claude-code-source/src/cli/print.ts`
+
+Findings:
+- `loadConversationForResume(source, sourceJsonlFile)` accepts a raw `.jsonl`
+  path.
+- Print mode routes `.jsonl` resume identifiers through that path.
+- This is described as the cross-directory resume path.
+
+Implication:
+- We do **not** need private bridge/session APIs to load dormant sessions.
+- The staged file can live in a temp directory; Claude Code will still load it.
+
+### 3. Session storage layout matters
+
+Relevant source:
+- `claude-code-source/src/utils/sessionStorage.ts`
+- `claude-code-source/src/utils/toolResultStorage.ts`
+- `claude-code-source/src/tools/AgentTool/runAgent.ts`
+
+Findings:
+- Main transcript path: `~/.claude/projects/<project-slug>/<session-id>.jsonl`
+- Session-specific artifacts live beside that transcript:
+  - `<project-dir>/<session-id>/tool-results/...`
+  - `<project-dir>/<session-id>/subagents/...`
+- Subagent transcripts are separate JSONL files under `subagents/`.
+- Content replacement / persisted tool output reconstruction depends on nearby
+  per-session artifact paths.
+
+Implication:
+- Staging should copy **more than one JSONL file** when needed.
+- The minimal viable stager must understand:
+  - main session JSONL
+  - session-sidecar directories (`tool-results`, possibly `subagents`)
+  - project-level files that influence prompt behavior (`CLAUDE.md`, memory)
+
+### 4. Compaction boundaries are real transcript boundaries, not just logical markers
+
+Relevant source:
+- `claude-code-source/src/utils/sessionStorage.ts`
+- `claude-code-source/src/services/compact/compact.ts`
+- `claude-code-source/src/utils/messages.ts`
+- `duncan-cc/src/tree.ts`
+
+Findings:
+- `compact_boundary` is a system message subtype.
+- Compaction resets / breaks parts of the parent chain around boundaries.
+- Duncan already reconstructs compaction windows with `buildRawChain()` and
+  `getCompactionWindows()`.
+- The existing Duncan pipeline works on **normalized logical windows**, but the
+  headless rewrite needs **raw-file-compatible staged transcripts**.
+
+Implication:
+- We need a staging layer that operates at **raw transcript-entry granularity**.
+- For compatibility, staged sessions should be created by:
+  1. copying the original session transcript,
+  2. truncating it at exact session-window boundaries,
+  3. renaming/writing it into a new session-shaped location.
+
+### 5. Branch/fork code shows Claude Code already tolerates transcript copying
+
+Relevant source:
+- `claude-code-source/src/commands/branch/branch.ts`
+
+Findings:
+- Claude Code already creates forked sessions by copying transcript entries to a
+  new file.
+- It preserves lots of original metadata and rewrites session-level identity.
+- It also carries content-replacement records forward.
+
+Implication:
+- File-based transcript staging is not alien to Claude Code’s own model.
+- We can borrow that mental model, even if our staging rules differ.
+
+### 6. Fanout overhead will come mostly from process startup + file staging
+
+Relevant source:
+- `duncan-cc/src/query.ts`
+- `claude-code-source/src/bridge/sessionRunner.ts`
+- `claude-code-source/src/cli/print.ts`
+
+Findings:
+- Current Duncan fanout is API-call concurrency (`batchSize`).
+- The headless rewrite will replace one API client call with one subprocess.
+- Claude’s own bridge session runner uses `--print`, `stream-json`, and a
+  session-oriented child process model.
+
+Implication:
+- The main resource costs to benchmark are:
+  - temp dir creation
+  - transcript copy/truncation size
+  - process spawn latency
+  - peak concurrent process count
+  - aggregate wall clock at 20-way fanout
+
+---
+
+## Rewrite Shape
+
+### High-level execution model
+
+```text
+Resolve target dormant session/window
+  ↓
+Stage an isolated ephemeral workspace
+  ↓
+Copy transcript + required sidecars
+  ↓
+Truncate transcript at chosen boundary/window
+  ↓
+Rename/write staged transcript into Claude-compatible layout
+  ↓
+Spawn `claude --print --resume <staged.jsonl>`
+  ↓
+Ask Duncan question through stdin/args
+  ↓
+Collect output + usage + diagnostics
+  ↓
+Destroy staged workspace
+```
+
+---
+
+## Proposed Modules
+
+### 1. `src/headless/session-stager.ts`
+
+Responsibilities:
+- create ephemeral stage dir
+- materialize Claude-compatible project/session layout
+- copy transcript + required sidecars
+- truncate transcript to the requested boundary/window
+- preserve raw JSONL entries by default
+- optionally rewrite session ids only when explicitly requested
+- return staged paths + staging stats
+
+Core types:
+- `StageRequest`
+- `StageResult`
+- `StagedSessionLayout`
+- `StageStats`
+
+### 2. `src/headless/session-boundaries.ts`
+
+Responsibilities:
+- map a dormant session into raw staging windows
+- identify safe truncate points
+- reject invalid cuts (e.g. mid-turn / malformed boundaries)
+
+Core types:
+- `SessionBoundary`
+- `BoundaryKind = "full" | "compaction-window" | "subagent"`
+- `BoundaryResolution`
+
+### 3. `src/headless/claude-runner.ts`
+
+Responsibilities:
+- spawn headless Claude Code subprocesses
+- standardize command-line args
+- collect stdout/stderr/exit status/duration
+- expose cancellation / timeout support
+
+Core types:
+- `HeadlessRunRequest`
+- `HeadlessRunResult`
+- `HeadlessRunner`
+
+### 4. `src/headless/fanout.ts`
+
+Responsibilities:
+- schedule many staged headless runs
+- control concurrency
+- collect resource/latency stats
+- report fanout overhead
+
+Core types:
+- `FanoutPlan`
+- `FanoutResult`
+- `FanoutMetrics`
+
+### 5. `src/headless/resource-meter.ts`
+
+Responsibilities:
+- capture lightweight benchmark/resource metrics for fanout tests
+- count bytes copied, temp dirs created, subprocess count, peak concurrency,
+  staging duration, run duration
+
+---
+
+## Three Spikes to Prove
+
+### Spike 1 — staged-session correctness
+
+Question:
+- Can we stage a dormant session into an isolated directory and produce the
+  exact file/layout shape our headless runner expects?
+
+Tests should prove:
+- stage dir is created deterministically
+- transcript is copied and renamed correctly
+- session-specific sidecars are copied into the right relative paths
+- staged session metadata points at the new stage, not the original path
+- raw transcript content is preserved by default
+- optional session-id rewriting is available when explicitly requested
+- no accidental mutation of the source transcript
+
+### Spike 2 — compaction-boundary compatibility
+
+Question:
+- Can we truncate at session/compaction boundaries in a way that remains
+  compatible with Claude Code’s resume expectations?
+
+Tests should prove:
+- no-boundary sessions stage as a single full transcript
+- compacted sessions can be split into stageable windows
+- truncation occurs only at safe entry boundaries
+- invalid mid-window truncation is rejected
+- staged transcripts preserve exact raw JSONL entries up to the cut
+
+### Spike 3 — 20-way fanout overhead
+
+Question:
+- Is 20-way ephemeral headless fanout operationally acceptable?
+
+Tests/benchmarks should measure:
+- bytes copied per stage
+- total temp storage written
+- spawn count
+- peak concurrent subprocesses
+- wall clock at configurable concurrency
+- average/median staging latency
+- average/median subprocess latency
+
+This spike does **not** need real Claude model calls in CI. A fake runner is
+acceptable for deterministic resource tests, as long as the real runner contract
+is the same.
+
+---
+
+## Test Strategy
+
+### Unit / contract tests
+
+1. `tests/headless-stager.test.ts`
+   - stage layout correctness
+   - copy isolation
+   - path rewriting behavior
+
+2. `tests/headless-boundaries.test.ts`
+   - raw boundary extraction
+   - safe truncation
+   - invalid boundary rejection
+
+3. `tests/headless-fanout.test.ts`
+   - fake 20-way fanout
+   - peak concurrency accounting
+   - aggregate bytes / temp dirs / wall clock metrics
+
+### Optional manual / integration spike
+
+4. `tests/headless-runner.integration.ts` (guarded / opt-in)
+   - only runs if a local `claude` binary is available
+   - stages a tiny fixture session
+   - invokes `claude --print --resume <jsonl>`
+   - asserts process success and machine-readable output shape
+
+---
+
+## Granular Implementation Plan
+
+### Phase A — research + contracts
+1. document Claude source findings and staging assumptions
+2. define `StageRequest`, `StageResult`, `HeadlessRunRequest`, `FanoutMetrics`
+3. add failing tests for the three spikes
+
+### Phase B — staging layer
+4. implement ephemeral workspace creation
+5. implement transcript copy + rename
+6. implement sidecar copy logic (`tool-results`, optional subagents)
+7. implement raw truncate-by-boundary helper
+8. make spike-1 + spike-2 tests pass
+
+### Phase C — headless runner
+9. implement subprocess wrapper for `claude --print --resume <jsonl>`
+10. standardize args/env/output capture
+11. add opt-in integration test hooks
+
+### Phase D — fanout harness
+12. implement fake-runner-compatible fanout executor
+13. add 20-way resource benchmark test
+14. record per-stage + aggregate metrics
+15. make spike-3 tests pass
+
+### Phase E — query-path integration
+16. add a parallel query mode that uses the new staged headless path
+17. keep the existing pipeline path intact during migration
+18. add toggle/config for choosing the execution backend
+
+### Phase F — migration
+19. compare answer quality / latency / token behavior
+20. decide whether to fully replace the reverse-engineered path
+21. remove obsolete auth/protocol code only after confidence is high
+
+---
+
+## Open Questions
+
+1. **What exact sidecars are mandatory for useful staged resume?**
+   - likely `tool-results/`
+   - possibly subagent files for some query modes
+
+2. **Do we need project-level memory/CLAUDE.md copied, symlinked, or merely
+   executed with cwd pointing at the original project?**
+
+3. **Should fanout stage by copying or by hardlinking where possible?**
+   - hardlinks reduce copy cost but complicate mutation safety guarantees
+
+4. **Should each staged run get a fresh synthetic session id, or can we safely
+   resume directly from a staged `.jsonl` path without rewriting IDs?**
+
+5. **Do we want the headless backend to coexist with the old API backend during
+   rollout, or replace it immediately on this branch?**
+
+---
+
+## Current Spike Findings
+
+Status after the first pass:
+- spike 1 — **passing**
+- spike 2 — **passing**
+- spike 3 — **passing**
+
+Concrete findings:
+- staging should preserve raw JSONL entries by default; forced transcript mutation created avoidable compatibility risk
+- unique ephemeral isolation can come from the staged directory/layout rather than rewriting every session id inside the transcript
+- explicit session-id rewriting is still useful as an opt-in escape hatch for experiments
+- compaction-window staging works best as exact raw-entry slicing from `compact_boundary` to the next boundary/end
+- a simple 20-target fanout harness is operationally cheap enough to keep iterating locally, with concurrency caps enforced in-process
+- a minimal `claude --print --resume <jsonl>` runner wrapper is straightforward; the remaining uncertainty is not invocation shape but fidelity of staged filesystem context
+
+Latest validation on this branch:
+- full `npm test` suite: **passing**
+- headless spike tests: **passing**
+
+## Current Recommendation
+
+Do **not** jump straight to a full rewrite.
+
+First prove, in order:
+1. staged-session correctness
+2. compaction-boundary truncation correctness
+3. 20-way fanout overhead
+
+Then wire the real headless runner behind those contracts.

--- a/docs/ephemeral-headless-rewrite.md
+++ b/docs/ephemeral-headless-rewrite.md
@@ -130,6 +130,14 @@ Implication:
   - session-sidecar directories (`tool-results`, possibly `subagents`)
   - project-level files that influence prompt behavior (`CLAUDE.md`, memory)
 
+Current fidelity strategy on this branch:
+- always copy `tool-results/` for headless queries
+- copy `subagents/` when the source transcript itself is a subagent transcript
+- infer the root session id from transcript entries, not just the filename, so subagent transcripts stage against the correct parent session sidecars
+- prefer running Claude with the transcript's original `cwd` when that directory still exists, so normal `CLAUDE.md` auto-discovery and live project context resolution keep working
+- fall back to the staged temp project dir only when the original `cwd` is unavailable
+- memory/CLAUDE.md are therefore currently handled by **original-cwd execution**, not by copying those files into the stage dir
+
 ### 4. Compaction boundaries are real transcript boundaries, not just logical markers
 
 Relevant source:
@@ -229,6 +237,19 @@ Responsibilities:
 - preserve raw JSONL entries by default
 - optionally rewrite session ids only when explicitly requested
 - return staged paths + staging stats
+
+### 1a. `src/headless/staged-session-manager.ts`
+
+Responsibilities:
+- allocate isolated per-run stage roots under a shared temp parent
+- write a small stage manifest for observability/debugging
+- clean staged derivative session files on success/failure
+- best-effort garbage collect stale stage roots from earlier crashes/interrupted runs
+
+Current behavior:
+- headless query execution now stages through the manager instead of calling the stager directly
+- stage cleanup runs in a `finally` block after each headless Claude invocation
+- stale run roots older than the GC threshold are removed opportunistically before new stage creation
 
 Core types:
 - `StageRequest`
@@ -470,9 +491,8 @@ Operational note:
 Do **not** jump straight to deleting the old path.
 
 Next implementation sequence:
-1. keep the existing API backend intact
-2. add an explicit backend selector (`api` vs `headless`)
-3. wire single-window headless execution first
-4. propagate that backend through batch/self/ancestor query flows
-5. keep warning users that higher `batchSize` values in headless mode require materially more memory
-6. only consider full replacement after correctness and operating-cost confidence are both high
+1. keep the API backend only as a temporary fallback
+2. make `headless` the branch default
+3. propagate that backend through batch/self/ancestor/subagent query flows
+4. keep warning users that higher `batchSize` values in headless mode require materially more memory
+5. only consider deleting the API fallback after correctness and operating-cost confidence are both high

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:system": "npx tsx tests/system-prompt.test.ts",
     "test:pipeline": "npx tsx tests/pipeline.test.ts",
     "test:discovery": "npx tsx tests/discovery.test.ts",
-    "test:self-exclusion": "npx tsx tests/self-exclusion.test.ts"
+    "test:self-exclusion": "npx tsx tests/self-exclusion.test.ts",
+    "bench:real-claude-fanout": "npx tsx benches/headless-fanout-real-claude.bench.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",

--- a/src/headless/claude-runner.ts
+++ b/src/headless/claude-runner.ts
@@ -6,6 +6,7 @@ export interface HeadlessRunRequest {
   cwd?: string;
   cliPath?: string;
   outputFormat?: "text" | "json" | "stream-json";
+  noSessionPersistence?: boolean;
   extraArgs?: string[];
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -29,6 +30,7 @@ export function buildClaudePrintArgs(request: HeadlessRunRequest): string[] {
     "--print",
     "--resume",
     request.resume,
+    ...(request.noSessionPersistence === false ? [] : ["--no-session-persistence"]),
     "--output-format",
     request.outputFormat ?? "json",
     ...(request.extraArgs ?? []),

--- a/src/headless/claude-runner.ts
+++ b/src/headless/claude-runner.ts
@@ -1,0 +1,95 @@
+import { spawn } from "node:child_process";
+
+export interface HeadlessRunRequest {
+  prompt?: string;
+  resume: string;
+  cwd?: string;
+  cliPath?: string;
+  outputFormat?: "text" | "json" | "stream-json";
+  extraArgs?: string[];
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+export interface HeadlessRunResult {
+  ok: boolean;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  command: string;
+  args: string[];
+}
+
+export function buildClaudePrintArgs(request: HeadlessRunRequest): string[] {
+  const args = [
+    "--print",
+    "--resume",
+    request.resume,
+    "--output-format",
+    request.outputFormat ?? "json",
+    ...(request.extraArgs ?? []),
+  ];
+  if (request.prompt) {
+    args.push(request.prompt);
+  }
+  return args;
+}
+
+export async function runClaudeHeadless(request: HeadlessRunRequest): Promise<HeadlessRunResult> {
+  const command = request.cliPath ?? "claude";
+  const args = buildClaudePrintArgs(request);
+  const start = Date.now();
+
+  return await new Promise<HeadlessRunResult>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: request.cwd,
+      env: { ...process.env, ...(request.env ?? {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let finished = false;
+    let timeout: NodeJS.Timeout | undefined;
+
+    const finish = (result: HeadlessRunResult) => {
+      if (finished) return;
+      finished = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      if (timeout) clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (exitCode, signal) => {
+      finish({
+        ok: exitCode === 0,
+        exitCode,
+        signal,
+        stdout,
+        stderr,
+        durationMs: Date.now() - start,
+        command,
+        args,
+      });
+    });
+
+    if (request.timeoutMs && request.timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+      }, request.timeoutMs);
+    }
+  });
+}

--- a/src/headless/claude-runner.ts
+++ b/src/headless/claude-runner.ts
@@ -9,10 +9,12 @@ export interface HeadlessRunRequest {
   extraArgs?: string[];
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  onSpawn?: (pid: number) => void;
 }
 
 export interface HeadlessRunResult {
   ok: boolean;
+  pid?: number;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   stdout: string;
@@ -48,6 +50,9 @@ export async function runClaudeHeadless(request: HeadlessRunRequest): Promise<He
       env: { ...process.env, ...(request.env ?? {}) },
       stdio: ["ignore", "pipe", "pipe"],
     });
+    if (child.pid) {
+      request.onSpawn?.(child.pid);
+    }
 
     let stdout = "";
     let stderr = "";
@@ -76,6 +81,7 @@ export async function runClaudeHeadless(request: HeadlessRunRequest): Promise<He
     child.on("close", (exitCode, signal) => {
       finish({
         ok: exitCode === 0,
+        pid: child.pid,
         exitCode,
         signal,
         stdout,

--- a/src/headless/fanout.ts
+++ b/src/headless/fanout.ts
@@ -1,0 +1,88 @@
+export interface FanoutMetrics {
+  targetCount: number;
+  spawnCount: number;
+  stageDirCount: number;
+  totalStagedBytes: number;
+  peakConcurrency: number;
+  wallTimeMs: number;
+  totalStageMs: number;
+  totalRunMs: number;
+  averageStageMs: number;
+  averageRunMs: number;
+}
+
+export interface StageFanoutResult<TStage> {
+  stage: TStage;
+  stagedBytes: number;
+  stageDirCount?: number;
+}
+
+export interface FanoutResult<TResult> {
+  results: TResult[];
+  metrics: FanoutMetrics;
+}
+
+export async function runFanout<TTarget, TStage, TResult>(
+  targets: TTarget[],
+  options: {
+    concurrency: number;
+    stageTarget: (target: TTarget, index: number) => Promise<StageFanoutResult<TStage>>;
+    runTarget: (target: TTarget, staged: TStage, index: number) => Promise<TResult>;
+  },
+): Promise<FanoutResult<TResult>> {
+  const concurrency = Math.max(1, options.concurrency);
+  const results = new Array<TResult>(targets.length);
+  let nextIndex = 0;
+  let active = 0;
+  let peakConcurrency = 0;
+  let spawnCount = 0;
+  let stageDirCount = 0;
+  let totalStagedBytes = 0;
+  let totalStageMs = 0;
+  let totalRunMs = 0;
+  const wallStart = Date.now();
+
+  const worker = async () => {
+    while (true) {
+      const currentIndex = nextIndex;
+      if (currentIndex >= targets.length) return;
+      nextIndex += 1;
+      const target = targets[currentIndex]!;
+      active += 1;
+      peakConcurrency = Math.max(peakConcurrency, active);
+      try {
+        const stageStart = Date.now();
+        const staged = await options.stageTarget(target, currentIndex);
+        totalStageMs += Date.now() - stageStart;
+        totalStagedBytes += staged.stagedBytes;
+        stageDirCount += staged.stageDirCount ?? 1;
+
+        const runStart = Date.now();
+        const result = await options.runTarget(target, staged.stage, currentIndex);
+        totalRunMs += Date.now() - runStart;
+        spawnCount += 1;
+        results[currentIndex] = result;
+      } finally {
+        active -= 1;
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, targets.length) }, () => worker()));
+
+  return {
+    results,
+    metrics: {
+      targetCount: targets.length,
+      spawnCount,
+      stageDirCount,
+      totalStagedBytes,
+      peakConcurrency,
+      wallTimeMs: Date.now() - wallStart,
+      totalStageMs,
+      totalRunMs,
+      averageStageMs: targets.length > 0 ? totalStageMs / targets.length : 0,
+      averageRunMs: targets.length > 0 ? totalRunMs / targets.length : 0,
+    },
+  };
+}

--- a/src/headless/query-backend.ts
+++ b/src/headless/query-backend.ts
@@ -1,11 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import { parseJsonl } from "../parser.js";
 import { runClaudeHeadless, type HeadlessRunRequest, type HeadlessRunResult } from "./claude-runner.js";
 import { deriveSessionWindowsFromEntries, type SessionWindowBoundary } from "./session-boundaries.js";
-import { stageSession } from "./session-stager.js";
+import { resolveHeadlessExecutionCwd, resolveHeadlessSourceContext } from "./source-context.js";
+import { StagedSessionManager } from "./staged-session-manager.js";
 
 export type QueryBackend = "api" | "headless";
 
@@ -29,6 +30,10 @@ export interface HeadlessQueryOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+const defaultStageManager = new StagedSessionManager({
+  stageRootDir: join(tmpdir(), "duncan-cc-headless-stage"),
+});
+
 export const DUNCAN_HEADLESS_JSON_SCHEMA = {
   type: "object",
   properties: {
@@ -40,8 +45,8 @@ export const DUNCAN_HEADLESS_JSON_SCHEMA = {
 } as const;
 
 export function resolveQueryBackend(explicit?: string | null): QueryBackend {
-  const value = explicit ?? process.env.DUNCAN_CC_QUERY_BACKEND ?? "api";
-  return value === "headless" ? "headless" : "api";
+  const value = explicit ?? process.env.DUNCAN_CC_QUERY_BACKEND ?? "headless";
+  return value === "api" ? "api" : "headless";
 }
 
 export async function resolveHeadlessWindowBoundary(
@@ -97,13 +102,17 @@ export async function querySingleWindowHeadless(
   opts: HeadlessQueryOptions = {},
 ): Promise<HeadlessQueryResult> {
   const window = await resolveHeadlessWindowBoundary(sessionFile, windowIndex);
-  const stage = await stageSession({
+  const sourceContext = await resolveHeadlessSourceContext(sessionFile);
+  const stageManager = opts.stageRootDir
+    ? new StagedSessionManager({ stageRootDir: opts.stageRootDir })
+    : defaultStageManager;
+  const staged = await stageManager.createStage({
     sourceSessionFile: sessionFile,
-    sourceProjectDir: dirname(sessionFile),
-    stageRootDir: opts.stageRootDir ?? join(tmpdir(), "duncan-cc-headless-stage"),
+    sourceProjectDir: sourceContext.sourceProjectDir,
+    sourceSessionId: sourceContext.sourceSessionId,
     window,
-    copyToolResults: false,
-    copySubagents: false,
+    copyToolResults: sourceContext.shouldCopyToolResults,
+    copySubagents: sourceContext.shouldCopySubagents,
   });
 
   const extraArgs: string[] = [
@@ -120,8 +129,8 @@ export async function querySingleWindowHeadless(
   }
 
   const runRequest: HeadlessRunRequest = {
-    cwd: stage.stageProjectDir,
-    resume: stage.stagedSessionFile,
+    cwd: await resolveHeadlessExecutionCwd(sourceContext.originalCwd, staged.stage.stageProjectDir),
+    resume: staged.stage.stagedSessionFile,
     prompt: buildHeadlessQuestionPrompt(question),
     outputFormat: "json",
     timeoutMs: opts.timeoutMs ?? 180000,
@@ -130,10 +139,13 @@ export async function querySingleWindowHeadless(
     extraArgs,
   };
 
-  const run = await runClaudeHeadless(runRequest);
-  if (!run.ok) {
-    throw new Error(run.stderr || run.stdout || `Headless Claude run failed with exit code ${run.exitCode}`);
+  try {
+    const run = await runClaudeHeadless(runRequest);
+    if (!run.ok) {
+      throw new Error(run.stderr || run.stdout || `Headless Claude run failed with exit code ${run.exitCode}`);
+    }
+    return parseHeadlessStructuredResult(run);
+  } finally {
+    await staged.cleanup();
   }
-
-  return parseHeadlessStructuredResult(run);
 }

--- a/src/headless/query-backend.ts
+++ b/src/headless/query-backend.ts
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { parseJsonl } from "../parser.js";
+import { runClaudeHeadless, type HeadlessRunRequest, type HeadlessRunResult } from "./claude-runner.js";
+import { deriveSessionWindowsFromEntries, type SessionWindowBoundary } from "./session-boundaries.js";
+import { stageSession } from "./session-stager.js";
+
+export type QueryBackend = "api" | "headless";
+
+export interface HeadlessQueryResult {
+  hasContext: boolean;
+  answer: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  latencyMs?: number;
+}
+
+export interface HeadlessQueryOptions {
+  model?: string;
+  cliPath?: string;
+  timeoutMs?: number;
+  stageRootDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export const DUNCAN_HEADLESS_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    hasContext: { type: "boolean" },
+    answer: { type: "string" },
+  },
+  required: ["hasContext", "answer"],
+  additionalProperties: false,
+} as const;
+
+export function resolveQueryBackend(explicit?: string | null): QueryBackend {
+  const value = explicit ?? process.env.DUNCAN_CC_QUERY_BACKEND ?? "api";
+  return value === "headless" ? "headless" : "api";
+}
+
+export async function resolveHeadlessWindowBoundary(
+  sessionFile: string,
+  windowIndex: number,
+): Promise<SessionWindowBoundary> {
+  const content = await readFile(sessionFile, "utf8");
+  const entries = parseJsonl(content);
+  const windows = deriveSessionWindowsFromEntries(entries);
+  const match = windows.find((window) => window.windowIndex === windowIndex);
+  if (!match) {
+    throw new Error(`Could not resolve raw session window ${windowIndex} for ${sessionFile}`);
+  }
+  return match;
+}
+
+export function buildHeadlessQuestionPrompt(question: string): string {
+  return [
+    "Answer solely based on the resumed conversation.",
+    "If you do not explicitly have enough context from the conversation, set hasContext=false and say so briefly in answer.",
+    question,
+  ].join("\n\n");
+}
+
+export function parseHeadlessStructuredResult(run: HeadlessRunResult): HeadlessQueryResult {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(run.stdout);
+  } catch (error) {
+    throw new Error(`Failed to parse headless Claude JSON output: ${String(error)}`);
+  }
+
+  const structured = parsed?.structured_output;
+  if (!structured || typeof structured !== "object") {
+    throw new Error(`Headless Claude response did not include structured_output`);
+  }
+  if (typeof structured.hasContext !== "boolean" || typeof structured.answer !== "string") {
+    throw new Error(`Headless Claude structured_output was malformed`);
+  }
+
+  return {
+    hasContext: structured.hasContext,
+    answer: structured.answer,
+    usage: parsed?.usage,
+    latencyMs: typeof run.durationMs === "number" ? run.durationMs : undefined,
+  };
+}
+
+export async function querySingleWindowHeadless(
+  sessionFile: string,
+  windowIndex: number,
+  question: string,
+  opts: HeadlessQueryOptions = {},
+): Promise<HeadlessQueryResult> {
+  const window = await resolveHeadlessWindowBoundary(sessionFile, windowIndex);
+  const stage = await stageSession({
+    sourceSessionFile: sessionFile,
+    sourceProjectDir: dirname(sessionFile),
+    stageRootDir: opts.stageRootDir ?? join(tmpdir(), "duncan-cc-headless-stage"),
+    window,
+    copyToolResults: false,
+    copySubagents: false,
+  });
+
+  const extraArgs: string[] = [
+    "--tools",
+    "",
+    "--effort",
+    "low",
+    "--json-schema",
+    JSON.stringify(DUNCAN_HEADLESS_JSON_SCHEMA),
+  ];
+  if (opts.model) {
+    extraArgs.unshift(opts.model);
+    extraArgs.unshift("--model");
+  }
+
+  const runRequest: HeadlessRunRequest = {
+    cwd: stage.stageProjectDir,
+    resume: stage.stagedSessionFile,
+    prompt: buildHeadlessQuestionPrompt(question),
+    outputFormat: "json",
+    timeoutMs: opts.timeoutMs ?? 180000,
+    cliPath: opts.cliPath,
+    env: opts.env,
+    extraArgs,
+  };
+
+  const run = await runClaudeHeadless(runRequest);
+  if (!run.ok) {
+    throw new Error(run.stderr || run.stdout || `Headless Claude run failed with exit code ${run.exitCode}`);
+  }
+
+  return parseHeadlessStructuredResult(run);
+}

--- a/src/headless/resource-sampler.ts
+++ b/src/headless/resource-sampler.ts
@@ -1,0 +1,117 @@
+import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface ProcessMemoryUsage {
+  rssBytes?: number;
+  virtualBytes?: number;
+}
+
+export interface ProcessSampleSnapshot {
+  timestamp: number;
+  processCount: number;
+  aggregateRssBytes?: number;
+  aggregateVirtualBytes?: number;
+}
+
+export interface SampleProcessSetResult {
+  samples: ProcessSampleSnapshot[];
+  sampleCount: number;
+  maxObservedProcessCount: number;
+  peakAggregateRssBytes?: number;
+  peakAggregateVirtualBytes?: number;
+}
+
+function parseStatusKb(text: string, key: "VmRSS" | "VmSize"): number | undefined {
+  const match = text.match(new RegExp(`^${key}:\\s+(\\d+)\\s+kB$`, "m"));
+  return match ? Number(match[1]) * 1024 : undefined;
+}
+
+export async function readProcessMemoryUsage(pid: number): Promise<ProcessMemoryUsage | undefined> {
+  try {
+    const status = await readFile(`/proc/${pid}/status`, "utf8");
+    return {
+      rssBytes: parseStatusKb(status, "VmRSS"),
+      virtualBytes: parseStatusKb(status, "VmSize"),
+    };
+  } catch {
+    // fall through
+  }
+
+  try {
+    const { stdout } = await execFileAsync("ps", ["-o", "rss=,vsz=", "-p", String(pid)], { timeout: 2000 });
+    const [rssKb, vszKb] = stdout.trim().split(/\s+/).map((value) => Number(value));
+    if (!Number.isFinite(rssKb) && !Number.isFinite(vszKb)) return undefined;
+    return {
+      rssBytes: Number.isFinite(rssKb) ? rssKb * 1024 : undefined,
+      virtualBytes: Number.isFinite(vszKb) ? vszKb * 1024 : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function sampleProcessSet(
+  getPids: () => Iterable<number>,
+  options: {
+    intervalMs?: number;
+    isDone: () => boolean;
+  },
+): Promise<SampleProcessSetResult> {
+  const intervalMs = options.intervalMs ?? 10;
+  const samples: ProcessSampleSnapshot[] = [];
+  let maxObservedProcessCount = 0;
+  let peakAggregateRssBytes: number | undefined;
+  let peakAggregateVirtualBytes: number | undefined;
+
+  while (true) {
+    const pids = [...getPids()].filter((pid) => Number.isInteger(pid) && pid > 0);
+    maxObservedProcessCount = Math.max(maxObservedProcessCount, pids.length);
+
+    let aggregateRssBytes = 0;
+    let aggregateVirtualBytes = 0;
+    let sawRss = false;
+    let sawVirtual = false;
+
+    const usages = await Promise.all(pids.map((pid) => readProcessMemoryUsage(pid)));
+    for (const usage of usages) {
+      if (!usage) continue;
+      if (typeof usage.rssBytes === "number") {
+        aggregateRssBytes += usage.rssBytes;
+        sawRss = true;
+      }
+      if (typeof usage.virtualBytes === "number") {
+        aggregateVirtualBytes += usage.virtualBytes;
+        sawVirtual = true;
+      }
+    }
+
+    const snapshot: ProcessSampleSnapshot = {
+      timestamp: Date.now(),
+      processCount: pids.length,
+      aggregateRssBytes: sawRss ? aggregateRssBytes : undefined,
+      aggregateVirtualBytes: sawVirtual ? aggregateVirtualBytes : undefined,
+    };
+    samples.push(snapshot);
+
+    if (typeof snapshot.aggregateRssBytes === "number") {
+      peakAggregateRssBytes = Math.max(peakAggregateRssBytes ?? 0, snapshot.aggregateRssBytes);
+    }
+    if (typeof snapshot.aggregateVirtualBytes === "number") {
+      peakAggregateVirtualBytes = Math.max(peakAggregateVirtualBytes ?? 0, snapshot.aggregateVirtualBytes);
+    }
+
+    if (options.isDone()) break;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return {
+    samples,
+    sampleCount: samples.length,
+    maxObservedProcessCount,
+    peakAggregateRssBytes,
+    peakAggregateVirtualBytes,
+  };
+}

--- a/src/headless/session-boundaries.ts
+++ b/src/headless/session-boundaries.ts
@@ -1,0 +1,88 @@
+import { parseJsonl } from "../parser.js";
+
+export type SessionWindowKind = "full" | "compaction";
+
+export interface SessionWindowBoundary {
+  windowIndex: number;
+  kind: SessionWindowKind;
+  startEntryIndex: number;
+  endEntryIndex: number;
+  includesCompactBoundary: boolean;
+}
+
+function isCompactBoundaryEntry(entry: any): boolean {
+  return entry?.type === "system" && entry?.subtype === "compact_boundary";
+}
+
+export function deriveSessionWindowsFromEntries(entries: any[]): SessionWindowBoundary[] {
+  if (entries.length === 0) return [];
+
+  const boundaryIndices: number[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    if (isCompactBoundaryEntry(entries[i])) {
+      boundaryIndices.push(i);
+    }
+  }
+
+  if (boundaryIndices.length === 0) {
+    return [{
+      windowIndex: 0,
+      kind: "full",
+      startEntryIndex: 0,
+      endEntryIndex: entries.length,
+      includesCompactBoundary: false,
+    }];
+  }
+
+  const windows: SessionWindowBoundary[] = [];
+
+  if (boundaryIndices[0] > 0) {
+    windows.push({
+      windowIndex: 0,
+      kind: "full",
+      startEntryIndex: 0,
+      endEntryIndex: boundaryIndices[0],
+      includesCompactBoundary: false,
+    });
+  }
+
+  for (let i = 0; i < boundaryIndices.length; i++) {
+    const start = boundaryIndices[i]!;
+    const end = i + 1 < boundaryIndices.length ? boundaryIndices[i + 1]! : entries.length;
+    windows.push({
+      windowIndex: windows.length,
+      kind: "compaction",
+      startEntryIndex: start,
+      endEntryIndex: end,
+      includesCompactBoundary: true,
+    });
+  }
+
+  return windows;
+}
+
+export function deriveSessionWindowsFromJsonl(content: string | Buffer): SessionWindowBoundary[] {
+  return deriveSessionWindowsFromEntries(parseJsonl(content));
+}
+
+export function validateSessionWindow(entries: any[], window: SessionWindowBoundary): void {
+  if (!Number.isInteger(window.startEntryIndex) || !Number.isInteger(window.endEntryIndex)) {
+    throw new Error("Session window indices must be integers");
+  }
+  if (window.startEntryIndex < 0 || window.endEntryIndex > entries.length || window.startEntryIndex >= window.endEntryIndex) {
+    throw new Error("Session window indices are out of bounds");
+  }
+  if (window.includesCompactBoundary && !isCompactBoundaryEntry(entries[window.startEntryIndex])) {
+    throw new Error("Compaction window must start at a compact_boundary entry");
+  }
+}
+
+export function sliceEntriesForWindow(entries: any[], window: SessionWindowBoundary): any[] {
+  validateSessionWindow(entries, window);
+  return entries.slice(window.startEntryIndex, window.endEntryIndex);
+}
+
+export function renderJsonl(entries: any[]): string {
+  if (entries.length === 0) return "";
+  return `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+}

--- a/src/headless/session-boundaries.ts
+++ b/src/headless/session-boundaries.ts
@@ -50,7 +50,7 @@ export function deriveSessionWindowsFromEntries(entries: any[]): SessionWindowBo
     const start = boundaryIndices[i]!;
     const end = i + 1 < boundaryIndices.length ? boundaryIndices[i + 1]! : entries.length;
     windows.push({
-      windowIndex: windows.length,
+      windowIndex: i + 1,
       kind: "compaction",
       startEntryIndex: start,
       endEntryIndex: end,

--- a/src/headless/session-stager.ts
+++ b/src/headless/session-stager.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "node:crypto";
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+import { parseJsonl } from "../parser.js";
+import { renderJsonl, sliceEntriesForWindow, type SessionWindowBoundary } from "./session-boundaries.js";
+
+export interface StageSessionRequest {
+  sourceSessionFile: string;
+  stageRootDir: string;
+  window: SessionWindowBoundary;
+  sourceProjectDir?: string;
+  stageProjectSlug?: string;
+  stagedSessionId?: string;
+  rewriteEntrySessionIds?: boolean;
+  copyToolResults?: boolean;
+  copySubagents?: boolean;
+}
+
+export interface StageSessionResult {
+  stageDir: string;
+  stageProjectDir: string;
+  stagedSessionFile: string;
+  sourceSessionId: string;
+  stagedSessionId: string;
+  stats: {
+    sourceBytes: number;
+    stagedBytes: number;
+    copiedToolResultFiles: number;
+    copiedSubagentFiles: number;
+  };
+}
+
+function replaceSessionIds(value: unknown, sourceSessionId: string, stagedSessionId: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => replaceSessionIds(entry, sourceSessionId, stagedSessionId));
+  }
+  if (!value || typeof value !== "object") {
+    return value === sourceSessionId ? stagedSessionId : value;
+  }
+  const input = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, entryValue] of Object.entries(input)) {
+    if ((key === "sessionId" || key === "session_id") && entryValue === sourceSessionId) {
+      out[key] = stagedSessionId;
+      continue;
+    }
+    out[key] = replaceSessionIds(entryValue, sourceSessionId, stagedSessionId);
+  }
+  if ("sessionId" in input || "session_id" in input) {
+    const normalizedSessionId = (out.sessionId ?? out.session_id ?? input.sessionId ?? input.session_id) === sourceSessionId
+      ? stagedSessionId
+      : (out.sessionId ?? out.session_id ?? input.sessionId ?? input.session_id);
+    out.sessionId = normalizedSessionId;
+    out.session_id = normalizedSessionId;
+  }
+  return out;
+}
+
+async function countFiles(dir: string): Promise<number> {
+  try {
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(dir, { withFileTypes: true });
+    let count = 0;
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) count += await countFiles(path);
+      else if (entry.isFile()) count += 1;
+    }
+    return count;
+  } catch {
+    return 0;
+  }
+}
+
+export async function stageSession(request: StageSessionRequest): Promise<StageSessionResult> {
+  const sourceProjectDir = request.sourceProjectDir ?? dirname(request.sourceSessionFile);
+  const sourceSessionId = basename(request.sourceSessionFile, ".jsonl");
+  const stagedSessionId = request.stagedSessionId ?? sourceSessionId;
+  const rewriteEntrySessionIds = request.rewriteEntrySessionIds ?? stagedSessionId !== sourceSessionId;
+  const stageProjectSlug = request.stageProjectSlug ?? basename(sourceProjectDir);
+  const stageDir = join(request.stageRootDir, `stage-${randomUUID()}`);
+  const stageProjectDir = join(stageDir, stageProjectSlug);
+  const stagedSessionFile = join(stageProjectDir, `${stagedSessionId}.jsonl`);
+
+  await mkdir(stageProjectDir, { recursive: true });
+
+  const sourceContent = await readFile(request.sourceSessionFile, "utf8");
+  const entries = parseJsonl(sourceContent);
+  const sliced = sliceEntriesForWindow(entries, request.window).map((entry) =>
+    rewriteEntrySessionIds ? replaceSessionIds(entry, sourceSessionId, stagedSessionId) : entry,
+  );
+  const stagedContent = renderJsonl(sliced as any[]);
+  await writeFile(stagedSessionFile, stagedContent, "utf8");
+
+  let copiedToolResultFiles = 0;
+  if (request.copyToolResults !== false) {
+    const sourceToolResults = join(sourceProjectDir, sourceSessionId, "tool-results");
+    const stagedToolResults = join(stageProjectDir, stagedSessionId, "tool-results");
+    try {
+      await mkdir(join(stageProjectDir, stagedSessionId), { recursive: true });
+      await cp(sourceToolResults, stagedToolResults, { recursive: true, force: true });
+      copiedToolResultFiles = await countFiles(stagedToolResults);
+    } catch {
+      copiedToolResultFiles = 0;
+    }
+  }
+
+  let copiedSubagentFiles = 0;
+  if (request.copySubagents) {
+    const sourceSubagents = join(sourceProjectDir, sourceSessionId, "subagents");
+    const stagedSubagents = join(stageProjectDir, stagedSessionId, "subagents");
+    try {
+      await mkdir(join(stageProjectDir, stagedSessionId), { recursive: true });
+      await cp(sourceSubagents, stagedSubagents, { recursive: true, force: true });
+      copiedSubagentFiles = await countFiles(stagedSubagents);
+    } catch {
+      copiedSubagentFiles = 0;
+    }
+  }
+
+  return {
+    stageDir,
+    stageProjectDir,
+    stagedSessionFile,
+    sourceSessionId,
+    stagedSessionId,
+    stats: {
+      sourceBytes: Buffer.byteLength(sourceContent),
+      stagedBytes: Buffer.byteLength(stagedContent),
+      copiedToolResultFiles,
+      copiedSubagentFiles,
+    },
+  };
+}

--- a/src/headless/session-stager.ts
+++ b/src/headless/session-stager.ts
@@ -10,6 +10,7 @@ export interface StageSessionRequest {
   stageRootDir: string;
   window: SessionWindowBoundary;
   sourceProjectDir?: string;
+  sourceSessionId?: string;
   stageProjectSlug?: string;
   stagedSessionId?: string;
   rewriteEntrySessionIds?: boolean;
@@ -75,7 +76,7 @@ async function countFiles(dir: string): Promise<number> {
 
 export async function stageSession(request: StageSessionRequest): Promise<StageSessionResult> {
   const sourceProjectDir = request.sourceProjectDir ?? dirname(request.sourceSessionFile);
-  const sourceSessionId = basename(request.sourceSessionFile, ".jsonl");
+  const sourceSessionId = request.sourceSessionId ?? basename(request.sourceSessionFile, ".jsonl");
   const stagedSessionId = request.stagedSessionId ?? sourceSessionId;
   const rewriteEntrySessionIds = request.rewriteEntrySessionIds ?? stagedSessionId !== sourceSessionId;
   const stageProjectSlug = request.stageProjectSlug ?? basename(sourceProjectDir);

--- a/src/headless/source-context.ts
+++ b/src/headless/source-context.ts
@@ -1,0 +1,73 @@
+import { access, readFile, stat } from "node:fs/promises";
+import { basename, dirname, sep } from "node:path";
+
+import { parseJsonl } from "../parser.js";
+
+export interface HeadlessSourceContext {
+  sourceProjectDir: string;
+  sourceSessionId: string;
+  originalCwd?: string;
+  isSubagentTranscript: boolean;
+  shouldCopyToolResults: boolean;
+  shouldCopySubagents: boolean;
+}
+
+function inferSourceProjectDir(sessionFile: string, sourceSessionId: string): { sourceProjectDir: string; isSubagentTranscript: boolean } {
+  const subagentNeedle = `${sep}${sourceSessionId}${sep}subagents${sep}`;
+  const explicitIdx = sessionFile.indexOf(subagentNeedle);
+  if (explicitIdx !== -1) {
+    return {
+      sourceProjectDir: sessionFile.slice(0, explicitIdx),
+      isSubagentTranscript: true,
+    };
+  }
+
+  const genericNeedle = `${sep}subagents${sep}`;
+  const genericIdx = sessionFile.indexOf(genericNeedle);
+  if (genericIdx !== -1) {
+    const beforeSubagents = sessionFile.slice(0, genericIdx);
+    return {
+      sourceProjectDir: dirname(beforeSubagents),
+      isSubagentTranscript: true,
+    };
+  }
+
+  return {
+    sourceProjectDir: dirname(sessionFile),
+    isSubagentTranscript: false,
+  };
+}
+
+export async function resolveHeadlessSourceContext(sessionFile: string): Promise<HeadlessSourceContext> {
+  const content = await readFile(sessionFile, "utf8");
+  const entries = parseJsonl(content);
+  const firstEntryWithSession = entries.find((entry) => typeof entry?.sessionId === "string" || typeof entry?.session_id === "string");
+  const firstEntryWithCwd = entries.find((entry) => typeof entry?.cwd === "string");
+  const sourceSessionId = firstEntryWithSession?.sessionId ?? firstEntryWithSession?.session_id ?? basename(sessionFile, ".jsonl");
+  const originalCwd = typeof firstEntryWithCwd?.cwd === "string" ? firstEntryWithCwd.cwd : undefined;
+  const inferred = inferSourceProjectDir(sessionFile, sourceSessionId);
+
+  return {
+    sourceProjectDir: inferred.sourceProjectDir,
+    sourceSessionId,
+    originalCwd,
+    isSubagentTranscript: inferred.isSubagentTranscript,
+    shouldCopyToolResults: true,
+    shouldCopySubagents: inferred.isSubagentTranscript,
+  };
+}
+
+export async function resolveHeadlessExecutionCwd(preferredCwd: string | undefined, fallbackCwd: string): Promise<string> {
+  if (preferredCwd) {
+    try {
+      await access(preferredCwd);
+      const info = await stat(preferredCwd);
+      if (info.isDirectory()) {
+        return preferredCwd;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return fallbackCwd;
+}

--- a/src/headless/staged-session-manager.ts
+++ b/src/headless/staged-session-manager.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+import { stageSession, type StageSessionRequest, type StageSessionResult } from "./session-stager.js";
+
+export interface StagedSessionHandle {
+  stage: StageSessionResult;
+  manifestPath: string;
+  cleanup: () => Promise<void>;
+}
+
+export interface StagedSessionManagerOptions {
+  stageRootDir?: string;
+  gcMaxAgeMs?: number;
+}
+
+interface StageManifest {
+  createdAt: string;
+  sourceSessionFile: string;
+  stageDir: string;
+  stagedSessionFile: string;
+}
+
+export class StagedSessionManager {
+  readonly stageRootDir: string;
+  readonly gcMaxAgeMs: number;
+
+  constructor(options: StagedSessionManagerOptions = {}) {
+    this.stageRootDir = options.stageRootDir ?? join(tmpdir(), "duncan-cc-headless-stage");
+    this.gcMaxAgeMs = options.gcMaxAgeMs ?? 6 * 60 * 60 * 1000;
+  }
+
+  async createStage(request: Omit<StageSessionRequest, "stageRootDir">): Promise<StagedSessionHandle> {
+    await mkdir(this.stageRootDir, { recursive: true });
+    await this.garbageCollect();
+    const isolatedRoot = await mkdtemp(join(this.stageRootDir, "run-"));
+    const stage = await stageSession({
+      ...request,
+      stageRootDir: isolatedRoot,
+    });
+    const manifestPath = join(stage.stageDir, "stage-manifest.json");
+    const manifest: StageManifest = {
+      createdAt: new Date().toISOString(),
+      sourceSessionFile: request.sourceSessionFile,
+      stageDir: stage.stageDir,
+      stagedSessionFile: stage.stagedSessionFile,
+    };
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+    return {
+      stage,
+      manifestPath,
+      cleanup: async () => {
+        await rm(isolatedRoot, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async garbageCollect(now = Date.now()): Promise<number> {
+    let removed = 0;
+    const entries = await readdir(this.stageRootDir, { withFileTypes: true }).catch(() => [] as any[]);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const candidate = join(this.stageRootDir, entry.name);
+      try {
+        const info = await stat(candidate);
+        if (now - info.mtimeMs > this.gcMaxAgeMs) {
+          await rm(candidate, { recursive: true, force: true });
+          removed += 1;
+          continue;
+        }
+        const nested = await readdir(candidate, { withFileTypes: true }).catch(() => [] as any[]);
+        for (const child of nested) {
+          if (!child.isDirectory()) continue;
+          const manifestPath = join(candidate, child.name, "stage-manifest.json");
+          const manifestText = await readFile(manifestPath, "utf8").catch(() => "");
+          if (!manifestText) continue;
+          const manifest = JSON.parse(manifestText) as StageManifest;
+          const createdAt = Date.parse(manifest.createdAt);
+          if (Number.isFinite(createdAt) && now - createdAt > this.gcMaxAgeMs) {
+            await rm(candidate, { recursive: true, force: true });
+            removed += 1;
+            break;
+          }
+        }
+      } catch {
+        // best effort
+      }
+    }
+    return removed;
+  }
+}
+
+export function getDefaultStageProjectSlug(sourceSessionFile: string): string {
+  return basename(sourceSessionFile, ".jsonl");
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -37,8 +37,8 @@ const server = new Server(
 // Tool definitions
 // ============================================================================
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+export function getToolDefinitions() {
+  return [
     {
       name: "duncan_query",
       description: buildDuncanQueryToolDescription(),
@@ -170,12 +170,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["mode"],
       },
     },
-  ],
-}));
+  ];
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: getToolDefinitions() }));
 
 // ============================================================================
 // Tool handlers
 // ============================================================================
+
+let handlers: ReturnType<typeof createDuncanHandlers>;
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args, _meta } = request.params;
@@ -185,11 +189,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   switch (name) {
     case "duncan_query":
-      return handleDuncanQuery(args as any, progressToken);
+      return handlers.handleDuncanQuery(args as any, progressToken);
     case "duncan_projects":
-      return handleListProjects(args as any);
+      return handlers.handleListProjects(args as any);
     case "duncan_list_sessions":
-      return handleListSessions(args as any);
+      return handlers.handleListSessions(args as any);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -224,312 +228,239 @@ async function sendProgress(progressToken: string | number | undefined, progress
   }
 }
 
-async function handleDuncanQuery(args: {
-  question: string;
-  mode: string;
-  projectDir?: string;
-  sessionId?: string;
-  cwd?: string;
-  limit?: number;
-  offset?: number;
-  includeSubagents?: boolean;
-  copies?: number;
-  backend?: "api" | "headless";
-  batchSize?: number;
-  gitBranch?: string;
-}, progressToken?: string | number) {
-  try {
-    // Self mode: query own active window N times for sampling diversity
-    if (args.mode === "self") {
-      const result = await querySelf(args.question, {
-        backend: args.backend,
-        copies: args.copies ?? 3,
-        batchSize: args.batchSize,
-        apiKey: undefined,
-        onProgress: (completed, total) => sendProgress(progressToken, completed, total),
-      });
+type HandlerDeps = {
+  findCallingSession: typeof findCallingSession;
+  queryBatch: typeof queryBatch;
+  querySelf: typeof querySelf;
+  queryAncestors: typeof queryAncestors;
+  querySubagents: typeof querySubagents;
+  listProjects: typeof listProjects;
+  resolveSessionFiles: typeof resolveSessionFiles;
+  extractSessionPreview: typeof extractSessionPreview;
+};
 
-      if (result.results.length === 0) {
+const defaultHandlerDeps: HandlerDeps = {
+  findCallingSession,
+  queryBatch,
+  querySelf,
+  queryAncestors,
+  querySubagents,
+  listProjects,
+  resolveSessionFiles,
+  extractSessionPreview,
+};
+
+export function createDuncanHandlers(deps: Partial<HandlerDeps> = {}) {
+  const resolvedDeps: HandlerDeps = { ...defaultHandlerDeps, ...deps };
+
+  const handleDuncanQuery = async (args: {
+    question: string;
+    mode: string;
+    projectDir?: string;
+    sessionId?: string;
+    cwd?: string;
+    limit?: number;
+    offset?: number;
+    includeSubagents?: boolean;
+    copies?: number;
+    backend?: "api" | "headless";
+    batchSize?: number;
+    gitBranch?: string;
+  }, progressToken?: string | number) => {
+    try {
+      if (args.mode === "self") {
+        const result = await resolvedDeps.querySelf(args.question, {
+          backend: args.backend,
+          copies: args.copies ?? 3,
+          batchSize: args.batchSize,
+          apiKey: undefined,
+          onProgress: (completed, total) => sendProgress(progressToken, completed, total),
+        });
+
+        if (result.results.length === 0) {
+          return {
+            content: [{ type: "text", text: "Could not find calling session for self-query." }],
+            isError: true,
+          };
+        }
+
+        const answers = result.results.map((r, i) => `### Sample ${i + 1}\n${r.result.answer}\n*— ${r.model}*`).join("\n\n---\n\n");
+        const contextCount = result.results.filter(r => r.result.hasContext).length;
         return {
-          content: [{ type: "text", text: "Could not find calling session for self-query." }],
-          isError: true,
+          content: [{ type: "text", text: `**${args.question}** (${result.results.length} samples)\n\n${answers}\n\n*${contextCount}/${result.results.length} had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*` }],
         };
       }
 
-      // Format: show all N answers
-      const answers = result.results.map((r, i) => {
-        return `### Sample ${i + 1}\n${r.result.answer}\n*— ${r.model}*`;
-      }).join("\n\n---\n\n");
+      if (args.mode === "ancestors") {
+        const result = await resolvedDeps.queryAncestors(args.question, {
+          backend: args.backend,
+          limit: args.limit ?? 50,
+          offset: args.offset ?? 0,
+          batchSize: args.batchSize,
+          apiKey: undefined,
+          onProgress: (completed, total) => sendProgress(progressToken, completed, total),
+        });
 
-      const contextCount = result.results.filter(r => r.result.hasContext).length;
-      return {
-        content: [{ type: "text", text: `**${args.question}** (${result.results.length} samples)\n\n${answers}\n\n*${contextCount}/${result.results.length} had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*` }],
-      };
-    }
+        if (result.results.length === 0) {
+          return { content: [{ type: "text", text: "No ancestor windows found. This session has no compaction boundaries." }] };
+        }
 
-    // Ancestors mode: query prior compaction windows of the calling session
-    if (args.mode === "ancestors") {
-      const result = await queryAncestors(args.question, {
-        backend: args.backend,
-        limit: args.limit ?? 50,
-        offset: args.offset ?? 0,
-        batchSize: args.batchSize,
-        apiKey: undefined,
-        onProgress: (completed, total) => sendProgress(progressToken, completed, total),
-      });
+        const withContext = result.results.filter(r => r.result.hasContext);
+        const relevant = withContext.length > 0 ? withContext : result.results;
+        const answers = relevant.map((r) => `${relevant.length === 1 ? "" : `### Window ${r.windowIndex}\n`}${r.result.answer}\n*— ${r.model}*`).join("\n\n---\n\n");
+        const parts = [`**${args.question}**\n\n${answers}`];
+        if (result.hasMore) {
+          const nextOffset = (args.offset ?? 0) + (args.limit ?? 50);
+          const remaining = result.totalWindows - nextOffset;
+          parts.push(`\n\n---\n*Queried ${result.results.length} of ${result.totalWindows} windows. ${remaining} more available — call again with offset: ${nextOffset}.*`);
+        }
+        parts.push(`\n\n*${withContext.length}/${result.results.length} windows had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
+        return { content: [{ type: "text", text: parts.join("") }] };
+      }
+
+      if (args.mode === "subagents") {
+        const result = await resolvedDeps.querySubagents(args.question, {
+          backend: args.backend,
+          limit: args.limit ?? 50,
+          offset: args.offset ?? 0,
+          batchSize: args.batchSize,
+          apiKey: undefined,
+          onProgress: (completed, total) => sendProgress(progressToken, completed, total),
+        });
+
+        if (result.results.length === 0) {
+          return { content: [{ type: "text", text: "No subagent transcripts found for this session." }] };
+        }
+
+        const errors = result.results.filter(r => r.result.answer.startsWith("Error: "));
+        const nonErrors = result.results.filter(r => !r.result.answer.startsWith("Error: "));
+        const withContext = nonErrors.filter(r => r.result.hasContext);
+        const relevant = withContext.length > 0 ? withContext : nonErrors.length > 0 ? nonErrors : result.results;
+        const answers = relevant.map((r) => `${relevant.length === 1 ? "" : `### ${r.sessionId.slice(0, 20)} (window ${r.windowIndex})\n`}${r.result.answer}\n*— ${r.model}*`).join("\n\n---\n\n");
+        const parts = [`**${args.question}**\n\n${answers}`];
+        if (errors.length > 0) {
+          const errorLines = errors.map(r => `- ${r.sessionId.slice(0, 20)} (window ${r.windowIndex}): ${r.result.answer}`).join("\n");
+          parts.push(`\n\n---\n**${errors.length} error(s):**\n${errorLines}`);
+        }
+        if (result.hasMore) {
+          const nextOffset = (args.offset ?? 0) + (args.limit ?? 50);
+          const remaining = result.totalWindows - nextOffset;
+          parts.push(`\n\n---\n*Queried ${result.results.length} of ${result.totalWindows} windows. ${remaining} more available — call again with offset: ${nextOffset}.*`);
+        }
+        parts.push(`\n\n*${withContext.length}/${result.results.length} subagent windows had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
+        return { content: [{ type: "text", text: parts.join("") }] };
+      }
+
+      const result = await resolvedDeps.queryBatch(
+        args.question,
+        {
+          mode: args.mode as any,
+          projectDir: args.projectDir,
+          sessionId: args.sessionId,
+          cwd: args.cwd ?? resolvedDeps.findCallingSession()?.cwd,
+          limit: args.limit ?? 10,
+          offset: args.offset ?? 0,
+          includeSubagents: args.includeSubagents ?? false,
+          gitBranch: args.gitBranch,
+        },
+        {
+          backend: args.backend,
+          apiKey: undefined,
+          batchSize: args.batchSize,
+          onProgress: (completed, total) => sendProgress(progressToken, completed, total),
+        },
+      );
 
       if (result.results.length === 0) {
-        return {
-          content: [{ type: "text", text: "No ancestor windows found. This session has no compaction boundaries." }],
-        };
+        return { content: [{ type: "text", text: "No sessions found matching the routing criteria." }] };
       }
 
-      const withContext = result.results.filter(r => r.result.hasContext);
-      const relevant = withContext.length > 0 ? withContext : result.results;
-
-      const answers = relevant.map((r) => {
-        const label = relevant.length === 1 ? "" : `### Window ${r.windowIndex}\n`;
-        return `${label}${r.result.answer}\n*— ${r.model}*`;
-      }).join("\n\n---\n\n");
-
-      const parts = [`**${args.question}**\n\n${answers}`];
-
-      if (result.hasMore) {
-        const nextOffset = (args.offset ?? 0) + (args.limit ?? 50);
-        const remaining = result.totalWindows - nextOffset;
-        parts.push(`\n\n---\n*Queried ${result.results.length} of ${result.totalWindows} windows. ${remaining} more available — call again with offset: ${nextOffset}.*`);
-      }
-
-      const contextCount = withContext.length;
-      parts.push(`\n\n*${contextCount}/${result.results.length} windows had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
-
-      return { content: [{ type: "text", text: parts.join("") }] };
-    }
-
-    // Subagents mode: query subagent transcripts of the calling session
-    if (args.mode === "subagents") {
-      const result = await querySubagents(args.question, {
-        backend: args.backend,
-        limit: args.limit ?? 50,
-        offset: args.offset ?? 0,
-        batchSize: args.batchSize,
-        apiKey: undefined,
-        onProgress: (completed, total) => sendProgress(progressToken, completed, total),
-      });
-
-      if (result.results.length === 0) {
-        return {
-          content: [{ type: "text", text: "No subagent transcripts found for this session." }],
-        };
-      }
-
-      const errors = result.results.filter(r => r.result.answer.startsWith("Error: "));
-      const nonErrors = result.results.filter(r => !r.result.answer.startsWith("Error: "));
-      const withContext = nonErrors.filter(r => r.result.hasContext);
+      const errors = result.results.filter((r) => r.result.answer.startsWith("Error: "));
+      const nonErrors = result.results.filter((r) => !r.result.answer.startsWith("Error: "));
+      const withContext = nonErrors.filter((r) => r.result.hasContext);
       const relevant = withContext.length > 0 ? withContext : nonErrors.length > 0 ? nonErrors : result.results;
-
-      const answers = relevant.map((r) => {
-        const label = relevant.length === 1 ? "" : `### ${r.sessionId.slice(0, 20)} (window ${r.windowIndex})\n`;
-        return `${label}${r.result.answer}\n*— ${r.model}*`;
-      }).join("\n\n---\n\n");
-
+      const answers = relevant.map((r) => `${relevant.length === 1 ? "" : `### ${r.sessionId.slice(0, 12)} (window ${r.windowIndex})\n`}${r.result.answer}\n*— ${r.model}*`).join("\n\n---\n\n");
       const parts = [`**${args.question}**\n\n${answers}`];
-
       if (errors.length > 0) {
-        const errorLines = errors.map(r => `- ${r.sessionId.slice(0, 20)} (window ${r.windowIndex}): ${r.result.answer}`).join("\n");
+        const errorLines = errors.map((r) => `- ${r.sessionId.slice(0, 12)} (window ${r.windowIndex}): ${r.result.answer}`).join("\n");
         parts.push(`\n\n---\n**${errors.length} error(s):**\n${errorLines}`);
       }
-
       if (result.hasMore) {
-        const nextOffset = (args.offset ?? 0) + (args.limit ?? 50);
+        const nextOffset = (args.offset ?? 0) + (args.limit ?? 10);
         const remaining = result.totalWindows - nextOffset;
         parts.push(`\n\n---\n*Queried ${result.results.length} of ${result.totalWindows} windows. ${remaining} more available — call again with offset: ${nextOffset}.*`);
       }
-
-      const contextCount = withContext.length;
-      parts.push(`\n\n*${contextCount}/${result.results.length} subagent windows had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
-
+      parts.push(`\n\n*${withContext.length}/${result.results.length} sessions had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
       return { content: [{ type: "text", text: parts.join("") }] };
-    }
-
-    const result = await queryBatch(
-      args.question,
-      {
-        mode: args.mode as any,
-        projectDir: args.projectDir,
-        sessionId: args.sessionId,
-        cwd: args.cwd ?? findCallingSession()?.cwd,
-        limit: args.limit ?? 10,
-        offset: args.offset ?? 0,
-        includeSubagents: args.includeSubagents ?? false,
-        gitBranch: args.gitBranch,
-      },
-      {
-        backend: args.backend,
-        apiKey: undefined,
-        batchSize: args.batchSize,
-        onProgress: (completed, total) => sendProgress(progressToken, completed, total),
-      },
-    );
-
-    if (result.results.length === 0) {
+    } catch (err: any) {
       return {
-        content: [{ type: "text", text: "No sessions found matching the routing criteria." }],
+        content: [{ type: "text", text: `Duncan query error: ${err.message}` }],
+        isError: true,
       };
     }
+  };
 
-    const errors = result.results.filter((r) => r.result.answer.startsWith("Error: "));
-    const nonErrors = result.results.filter((r) => !r.result.answer.startsWith("Error: "));
-    const withContext = nonErrors.filter((r) => r.result.hasContext);
-    const relevant = withContext.length > 0 ? withContext : nonErrors.length > 0 ? nonErrors : result.results;
-
-    const answers = relevant
-      .map((r) => {
-        const label = relevant.length === 1
-          ? ""
-          : `### ${r.sessionId.slice(0, 12)} (window ${r.windowIndex})\n`;
-        const modelLine = `\n*— ${r.model}*`;
-        return `${label}${r.result.answer}${modelLine}`;
-      })
-      .join("\n\n---\n\n");
-
-    const parts = [`**${args.question}**\n\n${answers}`];
-
-    if (errors.length > 0) {
-      const errorLines = errors.map((r) => `- ${r.sessionId.slice(0, 12)} (window ${r.windowIndex}): ${r.result.answer}`).join("\n");
-      parts.push(`\n\n---\n**${errors.length} error(s):**\n${errorLines}`);
-    }
-
-    if (result.hasMore) {
-      const nextOffset = (args.offset ?? 0) + (args.limit ?? 10);
-      const remaining = result.totalWindows - nextOffset;
-      parts.push(
-        `\n\n---\n*Queried ${result.results.length} of ${result.totalWindows} windows. ${remaining} more available — call again with offset: ${nextOffset}.*`,
-      );
-    }
-
-    const contextCount = withContext.length;
-    const totalCount = result.results.length;
-    parts.push(`\n\n*${contextCount}/${totalCount} sessions had relevant context. ${formatTokenStats(result.usage)}. queryId: ${result.queryId}*`);
-
-    return {
-      content: [{ type: "text", text: parts.join("") }],
-    };
-  } catch (err: any) {
-    return {
-      content: [{ type: "text", text: `Duncan query error: ${err.message}` }],
-      isError: true,
-    };
-  }
-}
-
-async function handleListProjects(args: {
-  limit?: number;
-  offset?: number;
-}) {
-  try {
-    const result = listProjects({ limit: args.limit, offset: args.offset });
-
-    if (result.projects.length === 0) {
-      return {
-        content: [{ type: "text", text: "No projects found." }],
-      };
-    }
-
-    const lines = result.projects.map((p) => {
-      const date = p.lastActivity.toISOString().slice(0, 16);
-      const branches = p.branches.length > 0 ? p.branches.join(", ") : "—";
-      return `${p.cwd}\n  sessions: ${p.sessionCount}  last: ${date}  branches: ${branches}`;
-    });
-
-    const header = `${result.totalCount} projects${result.hasMore ? ` (showing ${result.projects.length})` : ""}:`;
-    return {
-      content: [{ type: "text", text: `${header}\n\n${lines.join("\n\n")}` }],
-    };
-  } catch (err: any) {
-    return {
-      content: [{ type: "text", text: `Error listing projects: ${err.message}` }],
-      isError: true,
-    };
-  }
-}
-
-async function handleListSessions(args: {
-  mode: string;
-  projectDir?: string;
-  projectPath?: string;
-  cwd?: string;
-  limit?: number;
-  previews?: boolean;
-  previewLines?: number;
-}) {
-  try {
-    // Resolve projectDir from projectPath if provided
-    const projectDir = args.projectDir
-      ?? (args.projectPath ? join(getProjectsDir(), cwdToProjectDirName(args.projectPath)) : undefined);
-
-    const resolved = resolveSessionFiles({
-      mode: args.mode as any,
-      projectDir,
-      cwd: args.cwd ?? findCallingSession()?.cwd,
-      limit: args.limit ?? 20,
-    });
-
-    if (resolved.sessions.length === 0) {
-      return {
-        content: [{ type: "text", text: "No sessions found." }],
-      };
-    }
-
-    const showPreviews = args.previews !== false;
-    const previewLines = args.previewLines ?? 2;
-
-    const lines = resolved.sessions.map((s) => {
-      const date = s.mtime.toISOString().slice(0, 16);
-      const size = s.size > 1024 * 1024
-        ? `${(s.size / 1024 / 1024).toFixed(1)}MB`
-        : `${(s.size / 1024).toFixed(0)}KB`;
-
-      let line = `**${s.sessionId.slice(0, 12)}**  ${date}  ${size}`;
-
-      if (showPreviews) {
-        const preview = extractSessionPreview(s.path, previewLines);
-        if (preview.gitBranch) line += `  branch: ${preview.gitBranch}`;
-        if (preview.cwd) line += `\n  cwd: ${preview.cwd}`;
-
-        const roleIcon = (role: string) => role === "assistant" ? "◇" : "▸";
-        const formatMsg = (m: { role: string; text: string }) => {
-          const truncated = m.text.replace(/\n/g, " ").slice(0, 120);
-          return `${roleIcon(m.role)} ${truncated}${m.text.length > 120 ? "…" : ""}`;
-        };
-
-        if (preview.headMessages.length > 0) {
-          for (const m of preview.headMessages) {
-            line += `\n  ${formatMsg(m)}`;
-          }
-        }
-        if (preview.tailMessages.length > 0) {
-          line += `\n  ...`;
-          for (const m of preview.tailMessages) {
-            line += `\n  ${formatMsg(m)}`;
-          }
-        }
+  const handleListProjects = async (args: { limit?: number; offset?: number }) => {
+    try {
+      const result = resolvedDeps.listProjects({ limit: args.limit, offset: args.offset });
+      if (result.projects.length === 0) {
+        return { content: [{ type: "text", text: "No projects found." }] };
       }
+      const lines = result.projects.map((p) => {
+        const date = p.lastActivity.toISOString().slice(0, 16);
+        const branches = p.branches.length > 0 ? p.branches.join(", ") : "—";
+        return `${p.cwd}\n  sessions: ${p.sessionCount}  last: ${date}  branches: ${branches}`;
+      });
+      const header = `${result.totalCount} projects${result.hasMore ? ` (showing ${result.projects.length})` : ""}:`;
+      return { content: [{ type: "text", text: `${header}\n\n${lines.join("\n\n")}` }] };
+    } catch (err: any) {
+      return { content: [{ type: "text", text: `Error listing projects: ${err.message}` }], isError: true };
+    }
+  };
 
-      return line;
-    });
+  const handleListSessions = async (args: { mode: string; projectDir?: string; projectPath?: string; cwd?: string; limit?: number; previews?: boolean; previewLines?: number; }) => {
+    try {
+      const projectDir = args.projectDir ?? (args.projectPath ? join(getProjectsDir(), cwdToProjectDirName(args.projectPath)) : undefined);
+      const resolved = resolvedDeps.resolveSessionFiles({
+        mode: args.mode as any,
+        projectDir,
+        cwd: args.cwd ?? resolvedDeps.findCallingSession()?.cwd,
+        limit: args.limit ?? 20,
+      });
+      if (resolved.sessions.length === 0) {
+        return { content: [{ type: "text", text: "No sessions found." }] };
+      }
+      const showPreviews = args.previews !== false;
+      const previewLines = args.previewLines ?? 2;
+      const lines = resolved.sessions.map((s) => {
+        const date = s.mtime.toISOString().slice(0, 16);
+        const size = s.size > 1024 * 1024 ? `${(s.size / 1024 / 1024).toFixed(1)}MB` : `${(s.size / 1024).toFixed(0)}KB`;
+        let line = `**${s.sessionId.slice(0, 12)}**  ${date}  ${size}`;
+        if (showPreviews) {
+          const preview = resolvedDeps.extractSessionPreview(s.path, previewLines);
+          if (preview.gitBranch) line += `  branch: ${preview.gitBranch}`;
+          if (preview.cwd) line += `\n  cwd: ${preview.cwd}`;
+          const roleIcon = (role: string) => role === "assistant" ? "◇" : "▸";
+          const formatMsg = (m: { role: string; text: string }) => `${roleIcon(m.role)} ${m.text.replace(/\n/g, " ").slice(0, 120)}${m.text.length > 120 ? "…" : ""}`;
+          if (preview.headMessages.length > 0) for (const m of preview.headMessages) line += `\n  ${formatMsg(m)}`;
+          if (preview.tailMessages.length > 0) {
+            line += `\n  ...`;
+            for (const m of preview.tailMessages) line += `\n  ${formatMsg(m)}`;
+          }
+        }
+        return line;
+      });
+      const header = `${resolved.totalCount} sessions${resolved.hasMore ? ` (showing ${resolved.sessions.length})` : ""}:`;
+      return { content: [{ type: "text", text: `${header}\n\n${lines.join("\n\n")}` }] };
+    } catch (err: any) {
+      return { content: [{ type: "text", text: `Error listing sessions: ${err.message}` }], isError: true };
+    }
+  };
 
-    const header = `${resolved.totalCount} sessions${resolved.hasMore ? ` (showing ${resolved.sessions.length})` : ""}:`;
-    return {
-      content: [{ type: "text", text: `${header}\n\n${lines.join("\n\n")}` }],
-    };
-  } catch (err: any) {
-    return {
-      content: [{ type: "text", text: `Error listing sessions: ${err.message}` }],
-      isError: true,
-    };
-  }
+  return { handleDuncanQuery, handleListProjects, handleListSessions };
 }
+
+handlers = createDuncanHandlers();
 
 // ============================================================================
 // Start server
@@ -541,7 +472,9 @@ async function main() {
   console.error("duncan-cc MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
-});
+if (process.argv[1] && process.argv[1] === new URL(import.meta.url).pathname) {
+  main().catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,6 +22,7 @@ import {
 import { processSessionFile, processSessionWindows } from "./pipeline.js";
 import { resolveSessionFiles, getProjectsDir, listAllSessionFiles, listProjects, extractGitBranch, extractSessionPreview, cwdToProjectDirName, findCallingSession } from "./discovery.js";
 import { querySingleWindow, queryBatch, querySelf, queryAncestors, querySubagents } from "./query.js";
+import { buildBackendDescription, buildBatchSizeDescription, buildDuncanQueryToolDescription } from "./query-config.js";
 
 // ============================================================================
 // Server setup
@@ -40,10 +41,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: "duncan_query",
-      description:
-        "Query dormant Claude Code sessions to recall information from previous conversations. " +
-        "Loads session context and asks the target session's model whether it has relevant information. " +
-        "Use when you need to find something discussed in a previous CC session.",
+      description: buildDuncanQueryToolDescription(),
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -91,9 +89,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "number",
             description: "For 'self' mode: number of parallel queries for sampling diversity (default: 3).",
           },
+          backend: {
+            type: "string",
+            enum: ["api", "headless"],
+            description: buildBackendDescription(),
+          },
           batchSize: {
             type: "number",
-            description: "Max concurrent API calls per batch (default: 5).",
+            description: buildBatchSizeDescription(),
           },
           gitBranch: {
             type: "string",
@@ -231,6 +234,7 @@ async function handleDuncanQuery(args: {
   offset?: number;
   includeSubagents?: boolean;
   copies?: number;
+  backend?: "api" | "headless";
   batchSize?: number;
   gitBranch?: string;
 }, progressToken?: string | number) {
@@ -238,6 +242,7 @@ async function handleDuncanQuery(args: {
     // Self mode: query own active window N times for sampling diversity
     if (args.mode === "self") {
       const result = await querySelf(args.question, {
+        backend: args.backend,
         copies: args.copies ?? 3,
         batchSize: args.batchSize,
         apiKey: undefined,
@@ -265,6 +270,7 @@ async function handleDuncanQuery(args: {
     // Ancestors mode: query prior compaction windows of the calling session
     if (args.mode === "ancestors") {
       const result = await queryAncestors(args.question, {
+        backend: args.backend,
         limit: args.limit ?? 50,
         offset: args.offset ?? 0,
         batchSize: args.batchSize,
@@ -303,6 +309,7 @@ async function handleDuncanQuery(args: {
     // Subagents mode: query subagent transcripts of the calling session
     if (args.mode === "subagents") {
       const result = await querySubagents(args.question, {
+        backend: args.backend,
         limit: args.limit ?? 50,
         offset: args.offset ?? 0,
         batchSize: args.batchSize,
@@ -358,6 +365,7 @@ async function handleDuncanQuery(args: {
         gitBranch: args.gitBranch,
       },
       {
+        backend: args.backend,
         apiKey: undefined,
         batchSize: args.batchSize,
         onProgress: (completed, total) => sendProgress(progressToken, completed, total),

--- a/src/query-config.ts
+++ b/src/query-config.ts
@@ -5,12 +5,13 @@ export function buildDuncanQueryToolDescription(): string {
     "Query dormant Claude Code sessions to recall information from previous conversations.",
     "Loads session context and asks the target session's model whether it has relevant information.",
     "Use when you need to find something discussed in a previous CC session.",
+    "Default backend on this branch is the headless real-Claude path.",
     "Warning: larger batchSize values materially increase memory use for the headless real-Claude backend.",
   ].join(" ");
 }
 
 export function buildBackendDescription(): string {
-  return "Execution backend. 'api' uses the current direct Anthropic API path. 'headless' stages the transcript and runs real Claude Code via --print --resume.";
+  return "Execution backend. Default is 'headless', which stages the transcript and runs real Claude Code via --print --resume. 'api' remains available only as a temporary fallback on this branch.";
 }
 
 export function buildBatchSizeDescription(): string {

--- a/src/query-config.ts
+++ b/src/query-config.ts
@@ -1,0 +1,18 @@
+export const HEADLESS_BATCH_SIZE_WARNING = "Warning: in headless mode, memory scales roughly with batchSize; on a 4 GB test machine, 5 concurrent Claude subprocesses used about 1.45 GB RSS and 10 used about 2.73 GB RSS.";
+
+export function buildDuncanQueryToolDescription(): string {
+  return [
+    "Query dormant Claude Code sessions to recall information from previous conversations.",
+    "Loads session context and asks the target session's model whether it has relevant information.",
+    "Use when you need to find something discussed in a previous CC session.",
+    "Warning: larger batchSize values materially increase memory use for the headless real-Claude backend.",
+  ].join(" ");
+}
+
+export function buildBackendDescription(): string {
+  return "Execution backend. 'api' uses the current direct Anthropic API path. 'headless' stages the transcript and runs real Claude Code via --print --resume.";
+}
+
+export function buildBatchSizeDescription(): string {
+  return `Max concurrent queries per batch (default: 5). ${HEADLESS_BATCH_SIZE_WARNING}`;
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -14,6 +14,7 @@ import { homedir, platform, userInfo } from "node:os";
 import { processSessionFile, processSessionWindows, type PipelineResult, type WindowPipelineResult } from "./pipeline.js";
 import { resolveSessionFiles, findCallingSession, listAllSessionFiles, listSubagentFiles, type RoutingParams, type RoutingResult } from "./discovery.js";
 import { recordQuery, buildLogRecord } from "./query-logger.js";
+import { querySingleWindowHeadless, resolveQueryBackend, type QueryBackend } from "./headless/query-backend.js";
 
 // ============================================================================
 // OAuth token resolution
@@ -191,11 +192,28 @@ export async function querySingleWindow(
   pipeline: PipelineResult | WindowPipelineResult,
   question: string,
   opts: {
+    backend?: QueryBackend | string;
+    sessionFile?: string;
     apiKey?: string;
     model?: string;
     signal?: AbortSignal;
+    headlessCliPath?: string;
+    headlessStageRootDir?: string;
+    headlessTimeoutMs?: number;
   } = {},
 ): Promise<DuncanResult> {
+  const backend = resolveQueryBackend(opts.backend);
+  if (backend === "headless") {
+    if (!opts.sessionFile) throw new Error("Headless backend requires sessionFile");
+    const windowIndex = "windowIndex" in pipeline ? pipeline.windowIndex : 0;
+    return await querySingleWindowHeadless(opts.sessionFile, windowIndex, question, {
+      model: opts.model ?? pipeline.modelInfo?.modelId,
+      cliPath: opts.headlessCliPath,
+      stageRootDir: opts.headlessStageRootDir,
+      timeoutMs: opts.headlessTimeoutMs,
+    });
+  }
+
   const auth = resolveAuth(opts.apiKey);
   const isOAuth = !!auth.authToken;
   const client = new Anthropic({
@@ -356,11 +374,15 @@ export async function queryBatch(
   question: string,
   routing: RoutingParams,
   opts: {
+    backend?: QueryBackend | string;
     apiKey?: string;
     model?: string;
     signal?: AbortSignal;
     batchSize?: number;
     onProgress?: (completed: number, total: number) => void;
+    headlessCliPath?: string;
+    headlessStageRootDir?: string;
+    headlessTimeoutMs?: number;
   } = {},
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -435,9 +457,14 @@ export async function queryBatch(
       batch.map(async (target) => {
         try {
           const result = await querySingleWindow(target.pipeline, question, {
+            backend: opts.backend,
+            sessionFile: target.sessionFile,
             apiKey: opts.apiKey,
             model: opts.model ?? target.pipeline.modelInfo?.modelId,
             signal: opts.signal,
+            headlessCliPath: opts.headlessCliPath,
+            headlessStageRootDir: opts.headlessStageRootDir,
+            headlessTimeoutMs: opts.headlessTimeoutMs,
           });
           completed++;
           opts.onProgress?.(completed, targets.length);
@@ -501,12 +528,16 @@ export async function queryBatch(
 export async function querySelf(
   question: string,
   opts: {
+    backend?: QueryBackend | string;
     copies?: number;
     batchSize?: number;
     apiKey?: string;
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    headlessCliPath?: string;
+    headlessStageRootDir?: string;
+    headlessTimeoutMs?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -550,9 +581,14 @@ export async function querySelf(
   const queryOnce = async (): Promise<DuncanQueryResult> => {
     try {
       const result = await querySingleWindow(activeWindow, question, {
+        backend: opts.backend,
+        sessionFile: session.path,
         apiKey: opts.apiKey,
         model: opts.model ?? activeWindow.modelInfo?.modelId,
         signal: opts.signal,
+        headlessCliPath: opts.headlessCliPath,
+        headlessStageRootDir: opts.headlessStageRootDir,
+        headlessTimeoutMs: opts.headlessTimeoutMs,
       });
       completed++;
       opts.onProgress?.(completed, total);
@@ -619,6 +655,7 @@ export async function querySelf(
 export async function queryAncestors(
   question: string,
   opts: {
+    backend?: QueryBackend | string;
     limit?: number;
     offset?: number;
     batchSize?: number;
@@ -626,6 +663,9 @@ export async function queryAncestors(
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    headlessCliPath?: string;
+    headlessStageRootDir?: string;
+    headlessTimeoutMs?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -668,9 +708,14 @@ export async function queryAncestors(
       batch.map(async (window) => {
         try {
           const result = await querySingleWindow(window, question, {
+            backend: opts.backend,
+            sessionFile: session.path,
             apiKey: opts.apiKey,
             model: opts.model ?? window.modelInfo?.modelId,
             signal: opts.signal,
+            headlessCliPath: opts.headlessCliPath,
+            headlessStageRootDir: opts.headlessStageRootDir,
+            headlessTimeoutMs: opts.headlessTimeoutMs,
           });
           completed++;
           opts.onProgress?.(completed, page.length);
@@ -724,6 +769,7 @@ export async function queryAncestors(
 export async function querySubagents(
   question: string,
   opts: {
+    backend?: QueryBackend | string;
     limit?: number;
     offset?: number;
     batchSize?: number;
@@ -731,6 +777,9 @@ export async function querySubagents(
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    headlessCliPath?: string;
+    headlessStageRootDir?: string;
+    headlessTimeoutMs?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -785,9 +834,14 @@ export async function querySubagents(
       batch.map(async (target) => {
         try {
           const result = await querySingleWindow(target.pipeline, question, {
+            backend: opts.backend,
+            sessionFile: target.sessionFile,
             apiKey: opts.apiKey,
             model: opts.model ?? target.pipeline.modelInfo?.modelId,
             signal: opts.signal,
+            headlessCliPath: opts.headlessCliPath,
+            headlessStageRootDir: opts.headlessStageRootDir,
+            headlessTimeoutMs: opts.headlessTimeoutMs,
           });
           completed++;
           opts.onProgress?.(completed, page.length);

--- a/tests/claude-runner.test.ts
+++ b/tests/claude-runner.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+
+import { buildClaudePrintArgs } from "../src/headless/claude-runner.js";
+
+const defaultArgs = buildClaudePrintArgs({
+  resume: "/tmp/session.jsonl",
+  outputFormat: "json",
+  prompt: "pong",
+});
+assert.deepEqual(defaultArgs, [
+  "--print",
+  "--resume",
+  "/tmp/session.jsonl",
+  "--no-session-persistence",
+  "--output-format",
+  "json",
+  "pong",
+]);
+
+const optOutArgs = buildClaudePrintArgs({
+  resume: "/tmp/session.jsonl",
+  outputFormat: "json",
+  noSessionPersistence: false,
+});
+assert.deepEqual(optOutArgs, [
+  "--print",
+  "--resume",
+  "/tmp/session.jsonl",
+  "--output-format",
+  "json",
+]);
+
+console.log("claude-runner.test.ts: ok");

--- a/tests/duncan-query-handler.test.ts
+++ b/tests/duncan-query-handler.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import { createDuncanHandlers, getToolDefinitions } from "../src/mcp-server.js";
+
+const usage = { inputTokens: 10, outputTokens: 2, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 };
+
+const calls: Array<{ kind: string; backend?: string; batchSize?: number }> = [];
+const handlers = createDuncanHandlers({
+  findCallingSession: () => ({ cwd: "/tmp/project", sessionId: "session-current" } as any),
+  querySelf: async (_question, opts) => {
+    calls.push({ kind: "self", backend: opts.backend as string | undefined, batchSize: opts.batchSize });
+    return {
+      queryId: "q-self",
+      question: "where?",
+      results: [
+        { queryId: "q-self", sessionFile: "/tmp/s.jsonl", sessionId: "session-current", windowIndex: 1, windowType: "main", model: "sonnet", result: { hasContext: true, answer: "self answer" } },
+      ],
+      totalWindows: 1,
+      hasMore: false,
+      offset: 0,
+      usage,
+    };
+  },
+  queryAncestors: async (_question, opts) => {
+    calls.push({ kind: "ancestors", backend: opts.backend as string | undefined, batchSize: opts.batchSize });
+    return {
+      queryId: "q-anc",
+      question: "where?",
+      results: [
+        { queryId: "q-anc", sessionFile: "/tmp/a.jsonl", sessionId: "session-current", windowIndex: 0, windowType: "compaction", model: "sonnet", result: { hasContext: true, answer: "ancestor answer" } },
+      ],
+      totalWindows: 1,
+      hasMore: false,
+      offset: 0,
+      usage,
+    };
+  },
+  querySubagents: async (_question, opts) => {
+    calls.push({ kind: "subagents", backend: opts.backend as string | undefined, batchSize: opts.batchSize });
+    return {
+      queryId: "q-sub",
+      question: "where?",
+      results: [
+        { queryId: "q-sub", sessionFile: "/tmp/sub.jsonl", sessionId: "agent-1", windowIndex: 0, windowType: "subagent", model: "sonnet", result: { hasContext: false, answer: "subagent answer" } },
+      ],
+      totalWindows: 1,
+      hasMore: false,
+      offset: 0,
+      usage,
+    };
+  },
+  queryBatch: async (_question, _routing, opts) => {
+    calls.push({ kind: "batch", backend: opts.backend as string | undefined, batchSize: opts.batchSize });
+    return {
+      queryId: "q-batch",
+      question: "where?",
+      results: [
+        { queryId: "q-batch", sessionFile: "/tmp/p.jsonl", sessionId: "project-session", windowIndex: 0, windowType: "main", model: "sonnet", result: { hasContext: true, answer: "project answer" } },
+      ],
+      totalWindows: 1,
+      hasMore: false,
+      offset: 0,
+      usage,
+    };
+  },
+});
+
+const selfResult = await handlers.handleDuncanQuery({ question: "where?", mode: "self", backend: "headless", batchSize: 5 });
+assert.equal(selfResult.isError, undefined);
+assert.match(String(selfResult.content[0]?.text), /self answer/);
+assert.match(String(selfResult.content[0]?.text), /1\/1 had relevant context/);
+
+const ancestorsResult = await handlers.handleDuncanQuery({ question: "where?", mode: "ancestors", backend: "headless", batchSize: 5 });
+assert.match(String(ancestorsResult.content[0]?.text), /ancestor answer/);
+assert.match(String(ancestorsResult.content[0]?.text), /1\/1 windows had relevant context/);
+
+const subagentsResult = await handlers.handleDuncanQuery({ question: "where?", mode: "subagents", backend: "headless", batchSize: 5 });
+assert.match(String(subagentsResult.content[0]?.text), /subagent answer/);
+assert.match(String(subagentsResult.content[0]?.text), /0\/1 subagent windows had relevant context/);
+
+const projectResult = await handlers.handleDuncanQuery({ question: "where?", mode: "project", backend: "headless", batchSize: 5, projectDir: "/tmp/project" });
+assert.match(String(projectResult.content[0]?.text), /project answer/);
+assert.match(String(projectResult.content[0]?.text), /sessions had relevant context/);
+
+assert.deepEqual(calls, [
+  { kind: "self", backend: "headless", batchSize: 5 },
+  { kind: "ancestors", backend: "headless", batchSize: 5 },
+  { kind: "subagents", backend: "headless", batchSize: 5 },
+  { kind: "batch", backend: "headless", batchSize: 5 },
+]);
+
+const tool = getToolDefinitions().find((entry) => entry.name === "duncan_query");
+assert.ok(tool);
+assert.match(String(tool?.description), /headless/);
+assert.match(String((tool as any).inputSchema.properties.batchSize.description), /1\.45 GB RSS/);
+assert.match(String((tool as any).inputSchema.properties.backend.description), /temporary fallback/);
+
+console.log("duncan-query-handler.test.ts: ok");

--- a/tests/fixtures/headless-memory-child.mjs
+++ b/tests/fixtures/headless-memory-child.mjs
@@ -1,0 +1,11 @@
+const mb = Number(process.argv[2] ?? "4");
+const sleepMs = Number(process.argv[3] ?? "120");
+
+const bytes = Math.max(1, Math.floor(mb * 1024 * 1024));
+const buffer = Buffer.alloc(bytes, 1);
+for (let i = 0; i < buffer.length; i += 4096) {
+  buffer[i] = 1;
+}
+
+await new Promise((resolve) => setTimeout(resolve, sleepMs));
+process.stdout.write(JSON.stringify({ pid: process.pid, bytes: buffer.length }) + "\n");

--- a/tests/headless-boundaries.test.ts
+++ b/tests/headless-boundaries.test.ts
@@ -62,4 +62,12 @@ function boundary(uuid: string) {
   }), /Compaction window must start/);
 }
 
+{
+  const entries = [boundary("b1"), user("u2", "b1", "second")];
+  const windows = deriveSessionWindowsFromEntries(entries);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0]?.windowIndex, 1);
+  assert.equal(windows[0]?.kind, "compaction");
+}
+
 console.log("headless-boundaries.test.ts: ok");

--- a/tests/headless-boundaries.test.ts
+++ b/tests/headless-boundaries.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+
+import { deriveSessionWindowsFromEntries, renderJsonl, sliceEntriesForWindow, validateSessionWindow } from "../src/headless/session-boundaries.js";
+
+function user(uuid: string, parentUuid: string | null, text: string) {
+  return { type: "user", uuid, parentUuid, timestamp: new Date().toISOString(), sessionId: "session-src", message: { role: "user", content: text } };
+}
+
+function assistant(uuid: string, parentUuid: string | null, text: string) {
+  return { type: "assistant", uuid, parentUuid, timestamp: new Date().toISOString(), sessionId: "session-src", message: { role: "assistant", content: [{ type: "text", text }] } };
+}
+
+function boundary(uuid: string) {
+  return { type: "system", subtype: "compact_boundary", uuid, parentUuid: null, timestamp: new Date().toISOString(), sessionId: "session-src", message: { role: "system", content: "compact" } };
+}
+
+{
+  const entries = [user("u1", null, "hello"), assistant("a1", "u1", "hi")];
+  const windows = deriveSessionWindowsFromEntries(entries);
+  assert.equal(windows.length, 1);
+  assert.deepEqual(windows[0], {
+    windowIndex: 0,
+    kind: "full",
+    startEntryIndex: 0,
+    endEntryIndex: 2,
+    includesCompactBoundary: false,
+  });
+}
+
+{
+  const entries = [
+    user("u1", null, "first"),
+    assistant("a1", "u1", "reply1"),
+    boundary("b1"),
+    user("u2", "b1", "second"),
+    assistant("a2", "u2", "reply2"),
+    boundary("b2"),
+    user("u3", "b2", "third"),
+  ];
+  const windows = deriveSessionWindowsFromEntries(entries);
+  assert.equal(windows.length, 3);
+  assert.deepEqual(windows.map((w) => [w.kind, w.startEntryIndex, w.endEntryIndex]), [
+    ["full", 0, 2],
+    ["compaction", 2, 5],
+    ["compaction", 5, 7],
+  ]);
+
+  const secondWindowEntries = sliceEntriesForWindow(entries, windows[1]!);
+  assert.equal(secondWindowEntries[0].subtype, "compact_boundary");
+  assert.equal(secondWindowEntries.length, 3);
+  assert.equal(renderJsonl(secondWindowEntries).trim().split("\n").length, 3);
+}
+
+{
+  const entries = [user("u1", null, "first"), boundary("b1"), user("u2", "b1", "second")];
+  assert.throws(() => validateSessionWindow(entries, {
+    windowIndex: 99,
+    kind: "compaction",
+    startEntryIndex: 0,
+    endEntryIndex: 2,
+    includesCompactBoundary: true,
+  }), /Compaction window must start/);
+}
+
+console.log("headless-boundaries.test.ts: ok");

--- a/tests/headless-compaction-truncation.test.ts
+++ b/tests/headless-compaction-truncation.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { deriveSessionWindowsFromEntries, renderJsonl, validateSessionWindow } from "../src/headless/session-boundaries.js";
+import { stageSession } from "../src/headless/session-stager.js";
+
+const sessionId = "session-src";
+
+const entries = [
+  { type: "user", uuid: "u1", parentUuid: null, timestamp: new Date().toISOString(), sessionId, message: { role: "user", content: "before 1" } },
+  { type: "assistant", uuid: "a1", parentUuid: "u1", timestamp: new Date().toISOString(), sessionId, message: { role: "assistant", content: [{ type: "text", text: "reply 1" }], model: "claude-sonnet-4" } },
+  { type: "system", subtype: "compact_boundary", uuid: "b1", parentUuid: null, timestamp: new Date().toISOString(), sessionId, message: { role: "system", content: "compact 1" }, compactMetadata: { preservedSegment: { headUuid: "u1", tailUuid: "a1", anchorUuid: "b1" } } },
+  { type: "summary", leafUuid: "b1", summary: "summary 1" },
+  { type: "user", uuid: "u2", parentUuid: "b1", timestamp: new Date().toISOString(), sessionId, message: { role: "user", content: "after 1" } },
+  { type: "assistant", uuid: "a2", parentUuid: "u2", timestamp: new Date().toISOString(), sessionId, message: { role: "assistant", content: [{ type: "text", text: "reply 2" }], model: "claude-opus-4-1" } },
+  { type: "system", subtype: "compact_boundary", uuid: "b2", parentUuid: null, timestamp: new Date().toISOString(), sessionId, message: { role: "system", content: "compact 2" } },
+  { type: "summary", leafUuid: "b2", summary: "summary 2" },
+  { type: "content-replacement", sessionId, replacements: [{ kind: "tool_result", toolUseId: "toolu_123", replacement: "trimmed" }] },
+  { type: "user", uuid: "u3", parentUuid: "b2", timestamp: new Date().toISOString(), sessionId, message: { role: "user", content: "after 2" } },
+];
+
+{
+  const noCompactionEntries = entries.slice(0, 2);
+  const windows = deriveSessionWindowsFromEntries(noCompactionEntries);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0]?.kind, "full");
+  assert.equal(windows[0]?.startEntryIndex, 0);
+  assert.equal(windows[0]?.endEntryIndex, 2);
+}
+
+const windows = deriveSessionWindowsFromEntries(entries);
+assert.equal(windows.length, 3);
+assert.deepEqual(windows.map((window) => [window.kind, window.startEntryIndex, window.endEntryIndex]), [
+  ["full", 0, 2],
+  ["compaction", 2, 6],
+  ["compaction", 6, 10],
+]);
+
+assert.throws(() => validateSessionWindow(entries, {
+  windowIndex: 1,
+  kind: "compaction",
+  startEntryIndex: 3,
+  endEntryIndex: 6,
+  includesCompactBoundary: true,
+}), /Compaction window must start/);
+
+assert.throws(() => validateSessionWindow(entries, {
+  windowIndex: 1,
+  kind: "compaction",
+  startEntryIndex: 2,
+  endEntryIndex: 2,
+  includesCompactBoundary: true,
+}), /out of bounds/);
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-compaction-"));
+const sourceProjectDir = join(root, "project-src");
+const sourceSessionFile = join(sourceProjectDir, `${sessionId}.jsonl`);
+await mkdir(sourceProjectDir, { recursive: true });
+const sourceContent = renderJsonl(entries);
+await writeFile(sourceSessionFile, sourceContent, "utf8");
+
+const stage = await stageSession({
+  sourceSessionFile,
+  sourceProjectDir,
+  stageRootDir: join(root, "staged"),
+  window: windows[1]!,
+  stagedSessionId: sessionId,
+  copyToolResults: false,
+  copySubagents: false,
+});
+
+const stagedContent = await readFile(stage.stagedSessionFile, "utf8");
+const expectedContent = renderJsonl(entries.slice(windows[1]!.startEntryIndex, windows[1]!.endEntryIndex));
+assert.equal(stagedContent, expectedContent);
+assert.match(stagedContent, /compact_boundary/);
+assert.match(stagedContent, /"summary 1"/);
+assert.doesNotMatch(stagedContent, /"summary 2"/);
+assert.doesNotMatch(stagedContent, /"after 2"/);
+
+console.log("headless-compaction-truncation.test.ts: ok");

--- a/tests/headless-fanout-benchmark.test.ts
+++ b/tests/headless-fanout-benchmark.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { runFanout } from "../src/headless/fanout.js";
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-fanout-"));
+const targets = Array.from({ length: 20 }, (_, i) => ({
+  id: `target-${i}`,
+  bytes: 512 + i * 17,
+  stageDelayMs: 2 + (i % 3),
+  runDelayMs: 4 + (i % 4),
+}));
+
+let activeRuns = 0;
+let observedPeakRuns = 0;
+
+const result = await runFanout(targets, {
+  concurrency: 4,
+  stageTarget: async (target, index) => {
+    const stageDir = join(root, `stage-${index}`);
+    await mkdir(stageDir, { recursive: true });
+    const payload = `${target.id}:${"x".repeat(target.bytes - target.id.length - 1)}`;
+    await writeFile(join(stageDir, "session.jsonl"), payload, "utf8");
+    await sleep(target.stageDelayMs);
+    return {
+      stage: { stageDir, sessionFile: join(stageDir, "session.jsonl"), payloadBytes: Buffer.byteLength(payload) },
+      stagedBytes: Buffer.byteLength(payload),
+      stageDirCount: 1,
+    };
+  },
+  runTarget: async (target, staged, index) => {
+    activeRuns += 1;
+    observedPeakRuns = Math.max(observedPeakRuns, activeRuns);
+    try {
+      const content = await readFile(staged.sessionFile, "utf8");
+      await sleep(target.runDelayMs);
+      return {
+        ok: true,
+        index,
+        targetId: target.id,
+        stageDir: staged.stageDir,
+        observedBytes: Buffer.byteLength(content),
+      };
+    } finally {
+      activeRuns -= 1;
+    }
+  },
+});
+
+const expectedBytes = result.results.reduce((sum, entry) => sum + entry.observedBytes, 0);
+
+assert.equal(result.results.length, 20);
+assert.equal(result.metrics.targetCount, 20);
+assert.equal(result.metrics.spawnCount, 20);
+assert.equal(result.metrics.stageDirCount, 20);
+assert.equal(result.metrics.totalStagedBytes, expectedBytes);
+assert.ok(result.metrics.peakConcurrency <= 4, `fanout peak concurrency ${result.metrics.peakConcurrency} exceeded cap`);
+assert.ok(observedPeakRuns <= 4, `run peak concurrency ${observedPeakRuns} exceeded cap`);
+assert.ok(result.metrics.totalStageMs > 0);
+assert.ok(result.metrics.totalRunMs > 0);
+assert.ok(result.metrics.wallTimeMs > 0);
+assert.ok(result.metrics.averageStageMs > 0);
+assert.ok(result.metrics.averageRunMs > 0);
+
+console.log("headless-fanout-benchmark.test.ts: ok", JSON.stringify({
+  wallTimeMs: result.metrics.wallTimeMs,
+  totalStagedBytes: result.metrics.totalStagedBytes,
+  peakConcurrency: result.metrics.peakConcurrency,
+  observedPeakRuns,
+}));

--- a/tests/headless-fanout-memory.test.ts
+++ b/tests/headless-fanout-memory.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runFanout } from "../src/headless/fanout.js";
+import { sampleProcessSet } from "../src/headless/resource-sampler.js";
+
+async function fileSize(path: string): Promise<number> {
+  const info = await stat(path);
+  return info.size;
+}
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-memory-"));
+const childScript = join(process.cwd(), "tests", "fixtures", "headless-memory-child.mjs");
+const targets = Array.from({ length: 20 }, (_, i) => ({
+  id: `target-${i}`,
+  stageBytes: 64 * 1024 + i * 101,
+  childMemoryMb: 4,
+  childSleepMs: 180,
+}));
+
+const sweepResults: Array<Record<string, number | null>> = [];
+
+for (const concurrency of [1, 5, 10, 20]) {
+  const activePids = new Set<number>();
+  let finished = false;
+
+  const samplerPromise = sampleProcessSet(() => activePids, {
+    intervalMs: 5,
+    isDone: () => finished,
+  });
+
+  const result = await runFanout(targets, {
+    concurrency,
+    stageTarget: async (target, index) => {
+      const stageDir = join(root, `c${concurrency}`, `stage-${index}`);
+      const sessionFile = join(stageDir, "session.jsonl");
+      await mkdir(stageDir, { recursive: true });
+      const payload = `${target.id}:${"x".repeat(target.stageBytes - target.id.length - 1)}`;
+      await writeFile(sessionFile, payload, "utf8");
+      return {
+        stage: { stageDir, sessionFile, expectedBytes: Buffer.byteLength(payload), target },
+        stagedBytes: Buffer.byteLength(payload),
+        stageDirCount: 1,
+      };
+    },
+    runTarget: async (_target, staged, index) => {
+      const child = spawn(process.execPath, [childScript, String(staged.target.childMemoryMb), String(staged.target.childSleepMs)], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      if (child.pid) activePids.add(child.pid);
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        child.on("error", reject);
+        child.on("close", (code) => resolve(code ?? -1));
+      });
+      if (child.pid) activePids.delete(child.pid);
+
+      assert.equal(exitCode, 0, `child ${index} failed: ${stderr}`);
+      const observedBytes = await fileSize(staged.sessionFile);
+      assert.equal(observedBytes, staged.expectedBytes);
+      return { ok: true, observedBytes, stdoutLength: stdout.length };
+    },
+  });
+
+  finished = true;
+  const sample = await samplerPromise;
+  const totalObservedBytes = result.results.reduce((sum, entry) => sum + entry.observedBytes, 0);
+  const stageTreeBytes = targets.reduce((sum, target) => sum + target.stageBytes, 0);
+
+  assert.equal(result.metrics.targetCount, 20);
+  assert.equal(result.metrics.spawnCount, 20);
+  assert.equal(result.metrics.stageDirCount, 20);
+  assert.equal(result.metrics.totalStagedBytes, totalObservedBytes);
+  assert.ok(sample.maxObservedProcessCount <= concurrency, `observed ${sample.maxObservedProcessCount} active children with cap ${concurrency}`);
+  assert.ok(sample.sampleCount > 0);
+  assert.ok(result.metrics.totalStagedBytes >= stageTreeBytes);
+  if (sample.peakAggregateRssBytes !== undefined) {
+    assert.ok(sample.peakAggregateRssBytes > 0);
+  }
+  if (sample.peakAggregateVirtualBytes !== undefined) {
+    assert.ok(sample.peakAggregateVirtualBytes > 0);
+  }
+
+  sweepResults.push({
+    concurrency,
+    wallTimeMs: result.metrics.wallTimeMs,
+    peakProcesses: sample.maxObservedProcessCount,
+    peakRssBytes: sample.peakAggregateRssBytes ?? null,
+    peakVirtualBytes: sample.peakAggregateVirtualBytes ?? null,
+    totalStagedBytes: result.metrics.totalStagedBytes,
+  });
+}
+
+console.log("headless-fanout-memory.test.ts: ok", JSON.stringify(sweepResults));

--- a/tests/headless-fanout.test.ts
+++ b/tests/headless-fanout.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { runFanout } from "../src/headless/fanout.js";
+
+const targets = Array.from({ length: 20 }, (_, i) => ({ id: `target-${i}`, bytes: 100 + i }));
+
+const result = await runFanout(targets, {
+  concurrency: 5,
+  stageTarget: async (target, index) => {
+    await sleep(2);
+    return {
+      stage: { stageId: `stage-${index}`, targetId: target.id },
+      stagedBytes: target.bytes,
+      stageDirCount: 1,
+    };
+  },
+  runTarget: async (target, staged, index) => {
+    await sleep(4);
+    return { ok: true, targetId: target.id, stageId: staged.stageId, index };
+  },
+});
+
+assert.equal(result.results.length, 20);
+assert.equal(result.metrics.targetCount, 20);
+assert.equal(result.metrics.spawnCount, 20);
+assert.equal(result.metrics.stageDirCount, 20);
+assert.equal(result.metrics.totalStagedBytes, targets.reduce((sum, target) => sum + target.bytes, 0));
+assert.ok(result.metrics.peakConcurrency <= 5, `peak concurrency ${result.metrics.peakConcurrency} exceeded cap`);
+assert.ok(result.metrics.peakConcurrency >= 2, `expected some parallelism, got ${result.metrics.peakConcurrency}`);
+assert.ok(result.metrics.wallTimeMs >= 20, `expected measurable wall time, got ${result.metrics.wallTimeMs}`);
+assert.ok(result.metrics.averageStageMs >= 0);
+assert.ok(result.metrics.averageRunMs >= 0);
+
+console.log("headless-fanout.test.ts: ok");

--- a/tests/headless-query-backend.test.ts
+++ b/tests/headless-query-backend.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  DUNCAN_HEADLESS_JSON_SCHEMA,
+  buildHeadlessQuestionPrompt,
+  parseHeadlessStructuredResult,
+  resolveHeadlessWindowBoundary,
+  resolveQueryBackend,
+} from "../src/headless/query-backend.js";
+
+assert.equal(resolveQueryBackend(undefined), "api");
+process.env.DUNCAN_CC_QUERY_BACKEND = "headless";
+assert.equal(resolveQueryBackend(undefined), "headless");
+delete process.env.DUNCAN_CC_QUERY_BACKEND;
+assert.equal(resolveQueryBackend("headless"), "headless");
+assert.equal(resolveQueryBackend("api"), "api");
+assert.equal(resolveQueryBackend("weird"), "api");
+
+assert.match(buildHeadlessQuestionPrompt("where was the bug?"), /where was the bug\?/);
+assert.deepEqual(DUNCAN_HEADLESS_JSON_SCHEMA.required, ["hasContext", "answer"]);
+
+const parsed = parseHeadlessStructuredResult({
+  ok: true,
+  exitCode: 0,
+  signal: null,
+  stdout: JSON.stringify({
+    structured_output: { hasContext: true, answer: "in src/foo.ts" },
+    usage: { input_tokens: 1, output_tokens: 2 },
+  }),
+  stderr: "",
+  durationMs: 123,
+  command: "claude",
+  args: [],
+});
+assert.deepEqual(parsed, {
+  hasContext: true,
+  answer: "in src/foo.ts",
+  usage: { input_tokens: 1, output_tokens: 2 },
+  latencyMs: 123,
+});
+
+assert.throws(() => parseHeadlessStructuredResult({
+  ok: true,
+  exitCode: 0,
+  signal: null,
+  stdout: JSON.stringify({ result: "missing structured output" }),
+  stderr: "",
+  durationMs: 5,
+  command: "claude",
+  args: [],
+}), /structured_output/);
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-query-backend-"));
+const sourceSessionFile = join(root, "session.jsonl");
+await writeFile(sourceSessionFile, [
+  JSON.stringify({ type: "system", subtype: "compact_boundary", uuid: "b1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: "session-src", message: { role: "system", content: "compact" } }),
+  JSON.stringify({ type: "user", uuid: "u1", parentUuid: "b1", timestamp: new Date().toISOString(), sessionId: "session-src", message: { role: "user", content: "hi" } }),
+].join("\n") + "\n", "utf8");
+
+const boundary = await resolveHeadlessWindowBoundary(sourceSessionFile, 1);
+assert.equal(boundary.windowIndex, 1);
+assert.equal(boundary.kind, "compaction");
+assert.equal(boundary.startEntryIndex, 0);
+assert.equal(boundary.endEntryIndex, 2);
+
+const persisted = await readFile(sourceSessionFile, "utf8");
+assert.match(persisted, /compact_boundary/);
+
+console.log("headless-query-backend.test.ts: ok");

--- a/tests/headless-query-backend.test.ts
+++ b/tests/headless-query-backend.test.ts
@@ -11,13 +11,13 @@ import {
   resolveQueryBackend,
 } from "../src/headless/query-backend.js";
 
-assert.equal(resolveQueryBackend(undefined), "api");
-process.env.DUNCAN_CC_QUERY_BACKEND = "headless";
 assert.equal(resolveQueryBackend(undefined), "headless");
+process.env.DUNCAN_CC_QUERY_BACKEND = "api";
+assert.equal(resolveQueryBackend(undefined), "api");
 delete process.env.DUNCAN_CC_QUERY_BACKEND;
 assert.equal(resolveQueryBackend("headless"), "headless");
 assert.equal(resolveQueryBackend("api"), "api");
-assert.equal(resolveQueryBackend("weird"), "api");
+assert.equal(resolveQueryBackend("weird"), "headless");
 
 assert.match(buildHeadlessQuestionPrompt("where was the bug?"), /where was the bug\?/);
 assert.deepEqual(DUNCAN_HEADLESS_JSON_SCHEMA.required, ["hasContext", "answer"]);

--- a/tests/headless-source-context.test.ts
+++ b/tests/headless-source-context.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveHeadlessExecutionCwd, resolveHeadlessSourceContext } from "../src/headless/source-context.js";
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-source-context-"));
+const liveProjectDir = join(root, "live-project");
+await mkdir(liveProjectDir, { recursive: true });
+
+const mainProjectDir = join(root, "project-main");
+await mkdir(mainProjectDir, { recursive: true });
+const mainSessionFile = join(mainProjectDir, "session-main.jsonl");
+await writeFile(mainSessionFile, `${JSON.stringify({ type: "user", uuid: "u1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: "session-main", cwd: liveProjectDir, message: { role: "user", content: "hi" } })}\n`, "utf8");
+
+const mainContext = await resolveHeadlessSourceContext(mainSessionFile);
+assert.equal(mainContext.sourceProjectDir, mainProjectDir);
+assert.equal(mainContext.sourceSessionId, "session-main");
+assert.equal(mainContext.originalCwd, liveProjectDir);
+assert.equal(mainContext.isSubagentTranscript, false);
+assert.equal(mainContext.shouldCopyToolResults, true);
+assert.equal(mainContext.shouldCopySubagents, false);
+
+const subagentProjectDir = join(root, "project-sub");
+const subagentRootDir = join(subagentProjectDir, "session-root", "subagents", "worker-1");
+await mkdir(subagentRootDir, { recursive: true });
+const subagentFile = join(subagentRootDir, "agent-123.jsonl");
+await writeFile(subagentFile, `${JSON.stringify({ type: "assistant", uuid: "a1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: "session-root", cwd: liveProjectDir, message: { role: "assistant", content: [{ type: "text", text: "hello" }] } })}\n`, "utf8");
+
+const subagentContext = await resolveHeadlessSourceContext(subagentFile);
+assert.equal(subagentContext.sourceProjectDir, subagentProjectDir);
+assert.equal(subagentContext.sourceSessionId, "session-root");
+assert.equal(subagentContext.isSubagentTranscript, true);
+assert.equal(subagentContext.shouldCopyToolResults, true);
+assert.equal(subagentContext.shouldCopySubagents, true);
+
+const fallbackDir = join(root, "fallback");
+await mkdir(fallbackDir, { recursive: true });
+assert.equal(await resolveHeadlessExecutionCwd(liveProjectDir, fallbackDir), liveProjectDir);
+assert.equal(await resolveHeadlessExecutionCwd(join(root, "missing-cwd"), fallbackDir), fallbackDir);
+
+console.log("headless-source-context.test.ts: ok");

--- a/tests/headless-stager.test.ts
+++ b/tests/headless-stager.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { deriveSessionWindowsFromEntries } from "../src/headless/session-boundaries.js";
+import { stageSession } from "../src/headless/session-stager.js";
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-headless-stage-"));
+const sourceProjectDir = join(root, "project-src");
+const sourceSessionId = "session-src";
+const sourceSessionFile = join(sourceProjectDir, `${sourceSessionId}.jsonl`);
+
+await mkdir(join(sourceProjectDir, sourceSessionId, "tool-results"), { recursive: true });
+await writeFile(join(sourceProjectDir, sourceSessionId, "tool-results", "tool-1.txt"), "large output\n", "utf8");
+
+const entries = [
+  { type: "user", uuid: "u1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: sourceSessionId, session_id: sourceSessionId, message: { role: "user", content: "before compact" } },
+  { type: "assistant", uuid: "a1", parentUuid: "u1", timestamp: new Date().toISOString(), sessionId: sourceSessionId, message: { role: "assistant", content: [{ type: "text", text: "reply" }] } },
+  { type: "system", subtype: "compact_boundary", uuid: "b1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: sourceSessionId, message: { role: "system", content: "compact" } },
+  { type: "user", uuid: "u2", parentUuid: "b1", timestamp: new Date().toISOString(), sessionId: sourceSessionId, message: { role: "user", content: "after compact" } },
+];
+await writeFile(sourceSessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+
+const windows = deriveSessionWindowsFromEntries(entries);
+assert.equal(windows.length, 2);
+
+const fullStage = await stageSession({
+  sourceSessionFile,
+  sourceProjectDir,
+  stageRootDir: join(root, "staged"),
+  window: windows[0]!,
+});
+
+assert.equal(fullStage.stagedSessionId, sourceSessionId);
+assert.ok(fullStage.stagedSessionFile.endsWith(`${fullStage.stagedSessionId}.jsonl`));
+const fullStageContent = await readFile(fullStage.stagedSessionFile, "utf8");
+assert.equal(fullStageContent.trim().split("\n").length, 2);
+assert.ok(fullStage.stats.copiedToolResultFiles >= 1);
+const stagedToolResult = await readFile(join(fullStage.stageProjectDir, fullStage.stagedSessionId, "tool-results", "tool-1.txt"), "utf8");
+assert.equal(stagedToolResult, "large output\n");
+const fullStageEntries = fullStageContent.trim().split("\n").map((line) => JSON.parse(line));
+assert.equal(fullStageEntries[0].sessionId, sourceSessionId);
+assert.equal(fullStageEntries[0].session_id, sourceSessionId);
+
+const sourceContentAfterStage = await readFile(sourceSessionFile, "utf8");
+assert.equal(sourceContentAfterStage.trim().split("\n").length, 4);
+assert.match(sourceContentAfterStage, /session-src/);
+
+const compactStage = await stageSession({
+  sourceSessionFile,
+  sourceProjectDir,
+  stageRootDir: join(root, "staged-compact"),
+  window: windows[1]!,
+});
+const compactStageEntries = fullStageContent ? (await readFile(compactStage.stagedSessionFile, "utf8")).trim().split("\n").map((line) => JSON.parse(line)) : [];
+assert.equal(compactStageEntries.length, 2);
+assert.equal(compactStageEntries[0].subtype, "compact_boundary");
+assert.equal(compactStageEntries[0].sessionId, compactStage.stagedSessionId);
+assert.equal(compactStageEntries[0].session_id, undefined);
+
+const rewrittenStage = await stageSession({
+  sourceSessionFile,
+  sourceProjectDir,
+  stageRootDir: join(root, "staged-rewritten"),
+  window: windows[1]!,
+  stagedSessionId: "session-rewritten",
+  rewriteEntrySessionIds: true,
+});
+const rewrittenEntries = (await readFile(rewrittenStage.stagedSessionFile, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+assert.equal(rewrittenStage.stagedSessionId, "session-rewritten");
+assert.equal(rewrittenEntries[0].sessionId, "session-rewritten");
+assert.equal(rewrittenEntries[0].session_id, "session-rewritten");
+
+console.log("headless-stager.test.ts: ok");

--- a/tests/query-config.test.ts
+++ b/tests/query-config.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+
+import {
+  HEADLESS_BATCH_SIZE_WARNING,
+  buildBackendDescription,
+  buildBatchSizeDescription,
+  buildDuncanQueryToolDescription,
+} from "../src/query-config.js";
+
+assert.match(HEADLESS_BATCH_SIZE_WARNING, /1\.45 GB RSS/);
+assert.match(HEADLESS_BATCH_SIZE_WARNING, /2\.73 GB RSS/);
+assert.match(buildDuncanQueryToolDescription(), /batchSize/);
+assert.match(buildBackendDescription(), /headless/);
+assert.match(buildBatchSizeDescription(), /memory scales roughly with batchSize/);
+
+console.log("query-config.test.ts: ok");

--- a/tests/staged-session-manager.test.ts
+++ b/tests/staged-session-manager.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { deriveSessionWindowsFromEntries } from "../src/headless/session-boundaries.js";
+import { StagedSessionManager } from "../src/headless/staged-session-manager.js";
+
+const root = await mkdtemp(join(tmpdir(), "duncan-cc-stage-manager-"));
+const stageRootDir = join(root, "stages");
+const sourceProjectDir = join(root, "project-src");
+const sourceSessionId = "session-src";
+const sourceSessionFile = join(sourceProjectDir, `${sourceSessionId}.jsonl`);
+
+await mkdir(join(sourceProjectDir, sourceSessionId, "tool-results"), { recursive: true });
+await writeFile(join(sourceProjectDir, sourceSessionId, "tool-results", "tool-1.txt"), "out\n", "utf8");
+
+const entries = [
+  { type: "user", uuid: "u1", parentUuid: null, timestamp: new Date().toISOString(), sessionId: sourceSessionId, message: { role: "user", content: "hello" } },
+  { type: "assistant", uuid: "a1", parentUuid: "u1", timestamp: new Date().toISOString(), sessionId: sourceSessionId, message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+];
+await writeFile(sourceSessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+
+const windows = deriveSessionWindowsFromEntries(entries);
+const manager = new StagedSessionManager({ stageRootDir, gcMaxAgeMs: 1_000 });
+const handle = await manager.createStage({
+  sourceSessionFile,
+  sourceProjectDir,
+  window: windows[0]!,
+});
+
+const manifestText = await readFile(handle.manifestPath, "utf8");
+assert.match(manifestText, /sourceSessionFile/);
+await stat(handle.stage.stagedSessionFile);
+await handle.cleanup();
+await assert.rejects(() => stat(handle.stage.stageDir));
+
+const stale = await manager.createStage({
+  sourceSessionFile,
+  sourceProjectDir,
+  window: windows[0]!,
+});
+const staleTime = new Date(Date.now() - 10_000);
+await utimes(join(stageRootDir, (await readdirSafe(stageRootDir))[0]!), staleTime, staleTime);
+const removed = await manager.garbageCollect(Date.now());
+assert.ok(removed >= 1);
+await stale.cleanup();
+
+console.log("staged-session-manager.test.ts: ok");
+
+async function readdirSafe(dir: string): Promise<string[]> {
+  const { readdir } = await import("node:fs/promises");
+  return await readdir(dir);
+}


### PR DESCRIPTION
## Summary
- cut over duncan-cc on this branch to use the headless Claude backend by default
- add staged-session lifecycle management and source-context fidelity handling
- move the real-Claude fanout benchmark out of the default test path
- make headless Claude runs explicitly non-persistent with `--no-session-persistence`

## What changed
- added staged transcript/window slicing, source-context resolution, and cleanup/GC for derivative artifacts
- wired query flows to support the headless backend end-to-end, with api kept only as a temporary fallback toggle
- added handler-level tests for `duncan_query` routing across self/ancestors/subagents/project
- documented and surfaced `batchSize` memory warnings for the headless backend
- added real-Claude benchmark plumbing and kept it manual-only

## Validation
- `npm test`
- `DUNCAN_CC_REAL_BENCH_CONCURRENCIES=5 npm run bench:real-claude-fanout`
