### PR TITLE
Add readOnlyHint annotations for parallel tool execution

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,10 @@ const server = new Server(
 // Tool definitions
 // ============================================================================
 
+// readOnlyHint: Claude Code uses this to mark tools as concurrency-safe,
+// allowing parallel execution with other read-only tools. duncan_query does
+// append to ~/.claude/duncan.jsonl, but appendFileSync on POSIX is atomic
+// for single lines — no read-modify-write, no shared state, no corruption risk.
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -45,7 +49,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "Loads session context and asks the target session's model whether it has relevant information. " +
         "Use when you need to find something discussed in a previous CC session.",
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: true, // append-only log write is concurrency-safe
       },
       inputSchema: {
         type: "object" as const,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -44,6 +44,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "Query dormant Claude Code sessions to recall information from previous conversations. " +
         "Loads session context and asks the target session's model whether it has relevant information. " +
         "Use when you need to find something discussed in a previous CC session.",
+      annotations: {
+        readOnlyHint: true,
+      },
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -109,6 +112,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "List all Claude Code projects with metadata. Use to discover what projects exist " +
         "before targeting a specific project with duncan_query. Returns project directories, " +
         "session counts, last activity timestamps, and git branches.",
+      annotations: {
+        readOnlyHint: true,
+      },
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -131,6 +137,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "Use to discover sessions before querying. " +
         "Returns session IDs, timestamps, sizes, git branches, working directories, " +
         "and first/last user message previews.",
+      annotations: {
+        readOnlyHint: true,
+      },
       inputSchema: {
         type: "object" as const,
         properties: {


### PR DESCRIPTION
## Summary

- Adds `annotations: { readOnlyHint: true }` to all three MCP tool definitions (`duncan_query`, `duncan_projects`, `duncan_list_sessions`)
- Claude Code maps `readOnlyHint` → `isConcurrencySafe`, which allows tools to run in parallel with other concurrent-safe tools instead of serializing

## Concurrency safety note

`duncan_projects` and `duncan_list_sessions` are purely read-only. `duncan_query` does append to `~/.claude/duncan.jsonl` via `appendFileSync`, but this is concurrency-safe:

- Each write is a single `appendFileSync` call with a complete JSON line
- On POSIX (macOS/Linux), `O_APPEND` writes are atomic for sizes under the pipe buffer limit (~4KB) — a single JSONL record is well within that
- There's no read-modify-write pattern or shared mutable state between calls
- Concurrent appends produce independent lines with no interleaving risk

So while `duncan_query` isn't strictly read-only, its only side effect (append-only logging) is safe under concurrent execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)