### PR TITLE
Opus-4-7 model routing + context-window survival knobs

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -99,6 +99,23 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: "string",
             description: "For 'branch' mode: explicit git branch name. If omitted, uses the calling session's branch.",
           },
+          minimalSystemPrompt: {
+            type: "boolean",
+            description:
+              "Drop the full Claude Code system prompt (~3k tokens) and send a tiny placeholder instead. " +
+              "Use when a target window is near the 1M context cap and you need to shave tokens, " +
+              "or for simple recall queries that don't need the full CC persona. Default: false.",
+          },
+          maxPromptTokens: {
+            type: "number",
+            description:
+              "Hard cap on prompt tokens (system + messages). When the transcript would exceed this, " +
+              "drop the oldest messages one-by-one until the prompt fits and append a truncation note " +
+              "to the system prompt. Use when a target window is too big to query otherwise. " +
+              "Recommended: 950000 for 1M-context models (leaves ~5k headroom for output), " +
+              "180000 for 200k-context models. Truncation keeps the tail (most recent exchanges) " +
+              "and discards early history, so results reflect the end of the conversation.",
+          },
         },
         required: ["question", "mode"],
       },
@@ -233,6 +250,8 @@ async function handleDuncanQuery(args: {
   copies?: number;
   batchSize?: number;
   gitBranch?: string;
+  minimalSystemPrompt?: boolean;
+  maxPromptTokens?: number;
 }, progressToken?: string | number) {
   try {
     // Self mode: query own active window N times for sampling diversity
@@ -241,6 +260,8 @@ async function handleDuncanQuery(args: {
         copies: args.copies ?? 3,
         batchSize: args.batchSize,
         apiKey: undefined,
+        minimalSystemPrompt: args.minimalSystemPrompt,
+        maxPromptTokens: args.maxPromptTokens,
         onProgress: (completed, total) => sendProgress(progressToken, completed, total),
       });
 
@@ -269,6 +290,8 @@ async function handleDuncanQuery(args: {
         offset: args.offset ?? 0,
         batchSize: args.batchSize,
         apiKey: undefined,
+        minimalSystemPrompt: args.minimalSystemPrompt,
+        maxPromptTokens: args.maxPromptTokens,
         onProgress: (completed, total) => sendProgress(progressToken, completed, total),
       });
 
@@ -307,6 +330,8 @@ async function handleDuncanQuery(args: {
         offset: args.offset ?? 0,
         batchSize: args.batchSize,
         apiKey: undefined,
+        minimalSystemPrompt: args.minimalSystemPrompt,
+        maxPromptTokens: args.maxPromptTokens,
         onProgress: (completed, total) => sendProgress(progressToken, completed, total),
       });
 
@@ -360,6 +385,8 @@ async function handleDuncanQuery(args: {
       {
         apiKey: undefined,
         batchSize: args.batchSize,
+        minimalSystemPrompt: args.minimalSystemPrompt,
+        maxPromptTokens: args.maxPromptTokens,
         onProgress: (completed, total) => sendProgress(progressToken, completed, total),
       },
     );

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -129,13 +129,21 @@ export function isEphemeralProgress(type: string): boolean {
 
 /** API error message check — CC's Lt1() */
 const INTERNAL_ERROR_MODEL = "internal_error";
+const SYNTHETIC_ERROR_MODEL = "<synthetic>";
+
+/** Model strings that mark pseudo-assistant entries injected by the CC harness
+ * (API errors, "Prompt is too long" boundaries, etc.) and should never be
+ * forwarded to the Anthropic API as a real model id. */
+export const NON_REAL_ASSISTANT_MODELS: ReadonlySet<string> = new Set([
+  INTERNAL_ERROR_MODEL,
+  SYNTHETIC_ERROR_MODEL,
+]);
 
 export function isApiErrorMessage(entry: any): boolean {
-  return (
-    entry.type === "assistant" &&
-    entry.isApiErrorMessage === true &&
-    entry.message?.model === INTERNAL_ERROR_MODEL
-  );
+  if (entry?.type !== "assistant") return false;
+  if (entry.isApiErrorMessage === true) return true;
+  const model = entry.message?.model;
+  return typeof model === "string" && NON_REAL_ASSISTANT_MODELS.has(model);
 }
 
 /** Local command system message check — CC's gp1() */

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { parseSession, type ParsedSession } from "./parser.js";
+import { NON_REAL_ASSISTANT_MODELS, parseSession, type ParsedSession } from "./parser.js";
 import { buildRawChain, sliceFromBoundary, stripInternalFields, getCompactionWindows, type CompactionWindow } from "./tree.js";
 import { normalizeMessages } from "./normalize.js";
 import { applyContentReplacements, microcompact } from "./content-replacements.js";
@@ -45,6 +45,160 @@ export function toApiMessages(messages: CCMessage[]): ApiMessage[] {
   return messages.map(toApiMessage);
 }
 
+/**
+ * Tiny placeholder system prompt used when `minimalSystemPrompt` is set.
+ * Just enough to frame the task — the DUNCAN_PREFIX on the final user message
+ * and the forced duncan_response tool_choice carry the real instructions.
+ * Keeps the transcript interpretable without the ~3k-token CC persona.
+ */
+const MINIMAL_SYSTEM_PROMPT =
+  "You are reading a prior Claude Code session transcript to answer a question about it. " +
+  "Tool definitions (Read, Edit, Bash, Grep, etc.) are omitted but tool_use blocks in the " +
+  "transcript still show what was done and what results came back. Answer based solely on " +
+  "the transcript content.";
+
+/**
+ * Char-to-token ratio used for cheap token estimation on message/prompt text.
+ * Empirically calibrated against real CC session transcripts: a 2,817k-char
+ * ancestor window measured 1,012k actual tokens → 2.78 chars/token. Using
+ * 2.75 keeps us just-conservative so estimates match or slightly overshoot
+ * reality, which is the safe direction for truncation (we'd rather drop an
+ * extra message than fail the API call).
+ *
+ * English prose alone is closer to 3.5-4 chars/token — so for non-CC content
+ * this estimator overcounts, triggering unnecessary truncation. That's
+ * acceptable for the duncan use case; the inputs are always CC transcripts,
+ * which are dense in JSON / tool_use blocks / file paths.
+ */
+const CHARS_PER_TOKEN = 2.75;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function estimateMessageTokens(msg: ApiMessage): number {
+  const content =
+    typeof msg.content === "string"
+      ? msg.content
+      : JSON.stringify(msg.content);
+  // +4 for role + message overhead, matches Anthropic's rough-token guidance
+  return estimateTokens(content) + 4;
+}
+
+/**
+ * Collect all tool_use ids present in assistant messages.
+ * Used to find orphan tool_result blocks after head truncation.
+ */
+function collectToolUseIds(messages: ApiMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    if (!Array.isArray(m.content)) continue;
+    for (const block of m.content as any[]) {
+      if (block?.type === "tool_use" && typeof block.id === "string") {
+        ids.add(block.id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Drop tool_result blocks from a user message whose tool_use_id is not in
+ * the kept assistant tool_use ids. Returns null if the message ends up empty.
+ */
+function stripOrphanToolResults(msg: ApiMessage, keptToolUseIds: Set<string>): ApiMessage | null {
+  if (msg.role !== "user" || !Array.isArray(msg.content)) return msg;
+  const filtered = (msg.content as any[]).filter((block) => {
+    if (block?.type === "tool_result" && typeof block.tool_use_id === "string") {
+      return keptToolUseIds.has(block.tool_use_id);
+    }
+    return true;
+  });
+  if (filtered.length === 0) return null;
+  if (filtered.length === msg.content.length) return msg;
+  return { ...msg, content: filtered };
+}
+
+export interface TruncateHeadResult {
+  messages: ApiMessage[];
+  droppedCount: number;
+}
+
+/**
+ * Drop oldest messages from the head until `messages` plus `systemPromptTokens`
+ * fits under `maxPromptTokens`. Leaves a headroom of `reservedTokens` (default
+ * 5000) for the duncan_response tool output. After dropping, strips orphan
+ * tool_result blocks from the first kept user message.
+ *
+ * Returns the truncated list and the dropped count. If the input already fits,
+ * returns it unchanged with droppedCount=0.
+ */
+export function truncateHeadToFit(
+  messages: ApiMessage[],
+  systemPromptTokens: number,
+  maxPromptTokens: number,
+  reservedTokens: number = 5000,
+): TruncateHeadResult {
+  const budget = maxPromptTokens - systemPromptTokens - reservedTokens;
+  if (budget <= 0) {
+    return { messages: [], droppedCount: messages.length };
+  }
+
+  const perMsgTokens = messages.map(estimateMessageTokens);
+  let total = perMsgTokens.reduce((a, b) => a + b, 0);
+  if (total <= budget) return { messages, droppedCount: 0 };
+
+  const kept = [...messages];
+  const keptTokens = [...perMsgTokens];
+  let dropped = 0;
+
+  // Drop from head until we fit. Leave at least one message so the API
+  // has something to work with.
+  while (total > budget && kept.length > 1) {
+    kept.shift();
+    total -= keptTokens.shift()!;
+    dropped++;
+  }
+
+  // Strip orphan tool_result blocks from the first kept user message, since
+  // their tool_use just got dropped. If the first kept message empties out,
+  // drop it entirely and try again.
+  while (kept.length > 0) {
+    const toolUseIds = collectToolUseIds(kept);
+    // Only the very first message can be an orphan — later user messages
+    // reference tool_use blocks from assistant messages that are still present.
+    const first = kept[0];
+    const stripped = stripOrphanToolResults(first, toolUseIds);
+    if (stripped === null) {
+      kept.shift();
+      total -= keptTokens.shift()!;
+      dropped++;
+      continue;
+    }
+    if (stripped !== first) {
+      kept[0] = stripped;
+      const newTokens = estimateMessageTokens(stripped);
+      total = total - keptTokens[0] + newTokens;
+      keptTokens[0] = newTokens;
+    }
+    break;
+  }
+
+  return { messages: kept, droppedCount: dropped };
+}
+
+function appendTruncationNote(systemPrompt: string, droppedCount: number): string {
+  if (droppedCount === 0) return systemPrompt;
+  const note =
+    `\n\n# Transcript truncation notice\n` +
+    `The earliest ${droppedCount} message${droppedCount === 1 ? "" : "s"} of this session ` +
+    `were dropped to fit the prompt within the context window. You are seeing only the tail ` +
+    `of the conversation. If the question requires context from earlier in the session ` +
+    `that isn't visible in the remaining transcript, say so explicitly rather than guessing.`;
+  return systemPrompt ? systemPrompt + note : note.trimStart();
+}
+
 // ============================================================================
 // Pipeline Options
 // ============================================================================
@@ -64,6 +218,22 @@ export interface PipelineOptions {
   injectContext?: boolean;
   /** Skip system prompt building (default: false) */
   skipSystemPrompt?: boolean;
+  /**
+   * Emit a tiny placeholder system prompt instead of the full CC persona
+   * (default: false). Drops ~3k tokens. Useful when the session transcript
+   * is at or near the 1M context cap, or when the full persona isn't needed
+   * for simple recall queries.
+   */
+  minimalSystemPrompt?: boolean;
+  /**
+   * Cap on total prompt tokens (system + messages). When set and the pipeline
+   * output would exceed it, drop oldest messages from the head one-by-one
+   * until the prompt fits, then append a note to the system prompt explaining
+   * how many messages were dropped. Recommended: 950000 for 1M-context models,
+   * 180000 for 200k. Uses a char-based token estimate (chars / 3.5) so leave
+   * ~5k headroom below the hard limit.
+   */
+  maxPromptTokens?: number;
   /** CC project directory (~/.claude/projects/<hash>/) for memory loading */
   projectDir?: string | null;
   /** Agent type for subagent transcripts (from .meta.json) */
@@ -167,17 +337,29 @@ export function processSession(
 
   // 8. Build system prompt (full parity with CC's U2)
   const toolNames = extractToolNames(messages);
-  const systemPrompt = opts.skipSystemPrompt
+  let systemPrompt = opts.skipSystemPrompt
     ? ""
-    : buildSystemPromptString({
-        cwd: sessionCwd,
-        modelId: modelInfo?.modelId,
-        toolNames,
-        projectDir: opts.projectDir ?? null,
-      });
+    : opts.minimalSystemPrompt
+      ? MINIMAL_SYSTEM_PROMPT
+      : buildSystemPromptString({
+          cwd: sessionCwd,
+          modelId: modelInfo?.modelId,
+          toolNames,
+          projectDir: opts.projectDir ?? null,
+        });
 
   // 9. Convert to API format
-  const apiMessages = toApiMessages(messages);
+  let apiMessages = toApiMessages(messages);
+
+  // 10. Optional head truncation to fit under maxPromptTokens
+  if (opts.maxPromptTokens && opts.maxPromptTokens > 0) {
+    const sysTokens = estimateTokens(systemPrompt);
+    const truncated = truncateHeadToFit(apiMessages, sysTokens, opts.maxPromptTokens);
+    if (truncated.droppedCount > 0) {
+      apiMessages = truncated.messages;
+      systemPrompt = appendTruncationNote(systemPrompt, truncated.droppedCount);
+    }
+  }
 
   return {
     messages: apiMessages,
@@ -239,15 +421,28 @@ export function processSessionWindows(
       cwd: sessionCwd,
       modelId: modelInfo?.modelId,
     };
-    const systemPrompt = opts.skipSystemPrompt
+    let systemPrompt = opts.skipSystemPrompt
       ? ""
-      : opts.agentType
-        ? buildSubagentSystemPrompt(opts.agentType, promptOpts)
-        : buildSystemPromptString(promptOpts);
+      : opts.minimalSystemPrompt
+        ? MINIMAL_SYSTEM_PROMPT
+        : opts.agentType
+          ? buildSubagentSystemPrompt(opts.agentType, promptOpts)
+          : buildSystemPromptString(promptOpts);
+
+    let apiMessages = toApiMessages(messages);
+
+    if (opts.maxPromptTokens && opts.maxPromptTokens > 0) {
+      const sysTokens = estimateTokens(systemPrompt);
+      const truncated = truncateHeadToFit(apiMessages, sysTokens, opts.maxPromptTokens);
+      if (truncated.droppedCount > 0) {
+        apiMessages = truncated.messages;
+        systemPrompt = appendTruncationNote(systemPrompt, truncated.droppedCount);
+      }
+    }
 
     return {
       windowIndex: window.windowIndex,
-      messages: toApiMessages(messages),
+      messages: apiMessages,
       systemPrompt,
       modelInfo,
       rawMessageCount: window.messages.length,
@@ -270,10 +465,16 @@ function extractCwd(chain: CCMessage[]): string | undefined {
 }
 
 function extractModelInfo(chain: CCMessage[]): { provider: string; modelId: string } | undefined {
-  // Find the last assistant message with a model
+  // Find the last assistant message with a real model (skip API-error /
+  // <synthetic> entries injected by the CC harness — forwarding those to the
+  // Anthropic API 404s).
   for (let i = chain.length - 1; i >= 0; i--) {
     const msg = chain[i];
-    if (msg.type === "assistant" && msg.message.model) {
+    if (
+      msg.type === "assistant" &&
+      msg.message.model &&
+      !NON_REAL_ASSISTANT_MODELS.has(msg.message.model)
+    ) {
       return { provider: "anthropic", modelId: msg.message.model };
     }
   }

--- a/src/query.ts
+++ b/src/query.ts
@@ -361,6 +361,8 @@ export async function queryBatch(
     signal?: AbortSignal;
     batchSize?: number;
     onProgress?: (completed: number, total: number) => void;
+    minimalSystemPrompt?: boolean;
+    maxPromptTokens?: number;
   } = {},
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -398,6 +400,8 @@ export async function queryBatch(
     try {
       const windows = processSessionWindows(session.path, {
         agentType: session.agentType,
+        minimalSystemPrompt: opts.minimalSystemPrompt,
+        maxPromptTokens: opts.maxPromptTokens,
       });
       const isCalling = session.sessionId === callingSessionId;
 
@@ -507,6 +511,8 @@ export async function querySelf(
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    minimalSystemPrompt?: boolean;
+    maxPromptTokens?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -530,7 +536,10 @@ export async function querySelf(
   }
 
   // Process the session and get the LAST (active) window
-  const windows = processSessionWindows(session.path);
+  const windows = processSessionWindows(session.path, {
+    minimalSystemPrompt: opts.minimalSystemPrompt,
+    maxPromptTokens: opts.maxPromptTokens,
+  });
   if (windows.length === 0) {
     return {
       queryId, question, results: [], totalWindows: 0, hasMore: false, offset: 0, usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
@@ -626,6 +635,8 @@ export async function queryAncestors(
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    minimalSystemPrompt?: boolean;
+    maxPromptTokens?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -646,7 +657,10 @@ export async function queryAncestors(
   }
 
   // Get all windows, drop the last (active) one
-  const allWindows = processSessionWindows(session.path);
+  const allWindows = processSessionWindows(session.path, {
+    minimalSystemPrompt: opts.minimalSystemPrompt,
+    maxPromptTokens: opts.maxPromptTokens,
+  });
   const ancestorWindows = allWindows.slice(0, -1).filter(w => w.messages.length > 0);
 
   if (ancestorWindows.length === 0) {
@@ -731,6 +745,8 @@ export async function querySubagents(
     model?: string;
     signal?: AbortSignal;
     onProgress?: (completed: number, total: number) => void;
+    minimalSystemPrompt?: boolean;
+    maxPromptTokens?: number;
   },
 ): Promise<DuncanBatchResult> {
   const queryId = randomUUID();
@@ -759,7 +775,11 @@ export async function querySubagents(
   const allTargets: Array<{ sessionFile: string; sessionId: string; pipeline: WindowPipelineResult }> = [];
   for (const sub of subagentFiles) {
     try {
-      const windows = processSessionWindows(sub.path, { agentType: sub.agentType });
+      const windows = processSessionWindows(sub.path, {
+        agentType: sub.agentType,
+        minimalSystemPrompt: opts.minimalSystemPrompt,
+        maxPromptTokens: opts.maxPromptTokens,
+      });
       for (const w of windows) {
         if (w.messages.length === 0) continue;
         allTargets.push({ sessionFile: sub.path, sessionId: sub.sessionId, pipeline: w });

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -154,6 +154,7 @@ If you can say it in one sentence, don't use three. Prefer short, direct sentenc
 function knowledgeCutoff(modelId?: string): string | null {
   if (!modelId) return null;
   const id = modelId.toLowerCase();
+  if (id.includes("claude-opus-4-7")) return "January 2026";
   if (id.includes("claude-sonnet-4-6")) return "August 2025";
   if (id.includes("claude-opus-4-6")) return "May 2025";
   if (id.includes("claude-opus-4-5")) return "May 2025";

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CCMessage, ParsedSession } from "./parser.js";
-import { isCompactBoundary } from "./parser.js";
+import { isCompactBoundary, NON_REAL_ASSISTANT_MODELS } from "./parser.js";
 
 // ============================================================================
 // Leaf Detection
@@ -188,7 +188,11 @@ export function getCompactionWindows(chain: CCMessage[]): CompactionWindow[] {
     let info: { provider: string; modelId: string } | undefined;
     for (let i = start; i < end; i++) {
       const msg = chain[i];
-      if (msg.type === "assistant" && msg.message?.model) {
+      if (
+        msg.type === "assistant" &&
+        msg.message?.model &&
+        !NON_REAL_ASSISTANT_MODELS.has(msg.message.model)
+      ) {
         info = { provider: "anthropic", modelId: msg.message.model };
       }
     }

--- a/tests/compaction.test.ts
+++ b/tests/compaction.test.ts
@@ -5,6 +5,10 @@
 
 import { parseSession } from "../src/parser.js";
 import { buildRawChain, findBestLeaf, walkChain, sliceFromBoundary, getCompactionWindows } from "../src/tree.js";
+import { processSessionContent, processSessionWindows, truncateHeadToFit } from "../src/pipeline.js";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 let passed = 0;
 let failed = 0;
@@ -170,6 +174,159 @@ console.log("\n--- Model extraction per window ---");
   assert(windows[0].modelInfo?.modelId === "claude-opus-4-6", "window 0: opus");
   assert(windows[1].modelInfo?.modelId === "claude-sonnet-4-20250514", "window 1: sonnet");
   ok("model extraction per window");
+}
+
+console.log("\n--- minimalSystemPrompt emits a tiny placeholder ---");
+{
+  const u1 = id(), a1 = id();
+  const content = buildSession([
+    userMsg(u1, null, "hello"),
+    assistantMsg(a1, u1, "hi"),
+  ]);
+
+  const full = processSessionContent(content, undefined, {});
+  const minimal = processSessionContent(content, undefined, { minimalSystemPrompt: true });
+  const skipped = processSessionContent(content, undefined, { skipSystemPrompt: true });
+
+  assert(full.systemPrompt.length > 5000, `full prompt large (got ${full.systemPrompt.length} chars)`);
+  assert(minimal.systemPrompt.length > 0 && minimal.systemPrompt.length < 500, `minimal prompt short (got ${minimal.systemPrompt.length} chars)`);
+  assert(skipped.systemPrompt === "", "skipSystemPrompt yields empty string");
+  assert(minimal.systemPrompt !== full.systemPrompt, "minimal differs from full");
+  ok(`minimal prompt: ${minimal.systemPrompt.length} chars vs full ${full.systemPrompt.length}`);
+}
+
+console.log("\n--- minimalSystemPrompt threads through processSessionWindows ---");
+{
+  const u1 = id(), a1 = id();
+  const content = buildSession([
+    userMsg(u1, null, "hello"),
+    assistantMsg(a1, u1, "hi"),
+  ]);
+  const dir = mkdtempSync(join(tmpdir(), "duncan-test-"));
+  const file = join(dir, "session.jsonl");
+  writeFileSync(file, content);
+
+  const fullWindows = processSessionWindows(file, {});
+  const minWindows = processSessionWindows(file, { minimalSystemPrompt: true });
+  assert(fullWindows[0].systemPrompt.length > 5000, "window: full prompt large");
+  assert(minWindows[0].systemPrompt.length < 500 && minWindows[0].systemPrompt.length > 0, "window: minimal prompt short");
+  ok("processSessionWindows respects minimalSystemPrompt");
+}
+
+console.log("\n--- truncateHeadToFit: returns input unchanged when under budget ---");
+{
+  const msgs = [
+    { role: "user" as const, content: "hello" },
+    { role: "assistant" as const, content: "hi" },
+    { role: "user" as const, content: "more" },
+    { role: "assistant" as const, content: "sure" },
+  ];
+  const { messages, droppedCount } = truncateHeadToFit(msgs, 100, 100_000);
+  assert(droppedCount === 0, "no drops when under budget");
+  assert(messages.length === 4, "4 messages kept");
+  ok("under-budget passes through");
+}
+
+console.log("\n--- truncateHeadToFit: drops from head until fits ---");
+{
+  // Each message is ~1000 chars => ~286 tokens. Make 10 of them.
+  const big = "x".repeat(1000);
+  const msgs = Array.from({ length: 10 }, (_, i) => ({
+    role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    content: `${big}-${i}`,
+  }));
+  // Budget that should fit ~3-4 messages.
+  const { messages, droppedCount } = truncateHeadToFit(msgs, 0, 1500, 0);
+  assert(droppedCount > 0, `dropped some (got ${droppedCount})`);
+  assert(messages.length < 10, `kept fewer than 10 (got ${messages.length})`);
+  assert(messages.length > 0, "kept at least 1");
+  // Tail preserved — last kept message should be the last original message
+  const lastKept = messages[messages.length - 1];
+  const lastContent = typeof lastKept.content === "string" ? lastKept.content : "";
+  assert(lastContent.includes("-9"), `tail preserved (last content: ${lastContent.slice(0, 20)}...)`);
+  ok(`dropped ${droppedCount}, kept ${messages.length} tail messages`);
+}
+
+console.log("\n--- truncateHeadToFit: strips orphan tool_results after head drop ---");
+{
+  // Setup: user(tool_result for tu-A), assistant(tu-B), user(tool_result for tu-B), assistant(done)
+  // After dropping first 1: user(tool_result for tu-A, ORPHANED) → should strip that block
+  const msgs: any[] = [
+    { role: "assistant", content: [{ type: "tool_use", id: "tu-A", name: "Read", input: {} }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-A", content: "file content" }] },
+    { role: "assistant", content: [{ type: "tool_use", id: "tu-B", name: "Edit", input: {} }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-B", content: "edited" }] },
+  ];
+  // Budget that forces dropping the first assistant but keeps the tool_result user msg.
+  // Each message is tiny; force aggressive truncation.
+  const { messages, droppedCount } = truncateHeadToFit(msgs, 0, 50, 0);
+  // After the first drop, the user(tool_result for tu-A) has no matching tu-A → should be stripped
+  // or the whole message dropped if it had only that block.
+  for (const m of messages) {
+    if (m.role === "user" && Array.isArray(m.content)) {
+      for (const block of m.content as any[]) {
+        if (block.type === "tool_result") {
+          const keptToolUseIds = new Set<string>();
+          for (const mm of messages) {
+            if (mm.role === "assistant" && Array.isArray(mm.content)) {
+              for (const b of mm.content as any[]) {
+                if (b.type === "tool_use" && b.id) keptToolUseIds.add(b.id);
+              }
+            }
+          }
+          assert(keptToolUseIds.has(block.tool_use_id), `no orphan tool_results remain (${block.tool_use_id})`);
+        }
+      }
+    }
+  }
+  ok(`orphan tool_results stripped after drop (dropped ${droppedCount}, kept ${messages.length})`);
+}
+
+console.log("\n--- maxPromptTokens in pipeline: appends truncation note to system prompt ---");
+{
+  // Build a session with many turns
+  const entries: any[] = [];
+  let prev: string | null = null;
+  for (let i = 0; i < 20; i++) {
+    const u = id();
+    entries.push(userMsg(u, prev, "user text ".repeat(200)));
+    const a = id();
+    entries.push(assistantMsg(a, u, "assistant text ".repeat(200)));
+    prev = a;
+  }
+  const content = buildSession(entries);
+  // Use minimalSystemPrompt so headroom is small. Cap forces truncation but
+  // keeps enough budget to retain ~a few messages at the tail.
+  const truncated = processSessionContent(content, undefined, {
+    maxPromptTokens: 10_000,
+    minimalSystemPrompt: true,
+  });
+  const fullRes = processSessionContent(content, undefined, { minimalSystemPrompt: true });
+  assert(truncated.messages.length > 0, `kept some tail (got ${truncated.messages.length})`);
+  assert(truncated.messages.length < fullRes.messages.length, `truncated has fewer messages (${truncated.messages.length} < ${fullRes.messages.length})`);
+  assert(truncated.systemPrompt.includes("Transcript truncation notice"), "system prompt mentions truncation");
+  ok(`maxPromptTokens truncated ${fullRes.messages.length} → ${truncated.messages.length} messages (tail kept)`);
+}
+
+console.log("\n--- Model extraction skips <synthetic> / internal_error entries ---");
+{
+  // Regression: CC injects pseudo-assistant entries with model=<synthetic>
+  // (e.g. "Prompt is too long" errors at compaction boundaries) and
+  // model=internal_error. resolveModel must not latch onto these — forwarding
+  // them to the Anthropic API 404s with `model: <synthetic>`.
+  const u1 = id(), a1 = id(), aErr = id(), aSynth = id();
+  const content = buildSession([
+    userMsg(u1, null, "hello"),
+    { ...assistantMsg(a1, u1, "hi"), message: { role: "assistant", content: [{ type: "text", text: "hi" }], model: "claude-opus-4-7" } },
+    { ...assistantMsg(aErr, a1, "err"), isApiErrorMessage: true, message: { role: "assistant", content: [{ type: "text", text: "API error" }], model: "internal_error" } },
+    { ...assistantMsg(aSynth, aErr, "synth"), isApiErrorMessage: true, message: { role: "assistant", content: [{ type: "text", text: "Prompt is too long" }], model: "<synthetic>" } },
+  ]);
+  const parsed = parseSession(content);
+  const chain = buildRawChain(parsed);
+  const windows = getCompactionWindows(chain);
+
+  assert(windows[0].modelInfo?.modelId === "claude-opus-4-7", `expected claude-opus-4-7, got ${windows[0].modelInfo?.modelId}`);
+  ok("synthetic/internal_error entries skipped during model resolution");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Three tightly related changes for querying sessions from newer CC models and for very large transcripts:

1. **Skip `<synthetic>` / `internal_error` assistant entries in model resolution.** CC injects pseudo-assistant entries at API-error or \"Prompt is too long\" boundaries with `model=<synthetic>`; the previous resolver latched onto them and forwarded `<synthetic>` to the Anthropic API, 404ing with `model: <synthetic>`. Now `isApiErrorMessage` also matches `isApiErrorMessage:true` alone or `model in {<synthetic>, internal_error}`, and both `resolveModel` / `extractModelInfo` skip those entries.

2. **Add `minimalSystemPrompt` option.** Emits a ~280-char placeholder system prompt instead of the full ~11k-char CC persona, saving ~3k tokens. Useful when the transcript is near the 1M context cap or for simple recall queries that don't need the full CC persona.

3. **Add `maxPromptTokens` option with head truncation.** When set, drops oldest messages from the transcript until the prompt fits under the cap, strips orphan `tool_result` blocks (whose `tool_use` was just dropped), and appends a \"Transcript truncation notice\" to the system prompt explaining how many messages were dropped. `CHARS_PER_TOKEN` tuned to 2.75 — calibrated against a real CC transcript (2,817k chars → 1,012k actual tokens = 2.78 chars/tok).

Also teach `knowledgeCutoff` about `claude-opus-4-7` → January 2026.

## Motivation

Hit this while trying to query an ancestor window of a compacted opus-4-7 session:

- First failure mode was `404 not_found_error \"model: <synthetic>\"` — the session's compaction boundary has a synthetic assistant entry whose `model` field leaked into duncan's API call.
- After that fix, the ancestor window was 1,014,842 prompt tokens — ~15k over the 1M cap. `minimalSystemPrompt` alone shaved ~3k. `maxPromptTokens: 950000` truncated the head by 83 messages (keeping 912 tail messages), bringing the call down to ~922k tokens and letting the query succeed.

## Test plan

- [x] `npm test` passes (48 tests, including 7 new)
- [x] New tests cover: synthetic-model skipping, minimal prompt through both pipeline entry points, under-budget passthrough, head truncation, orphan tool_result stripping, truncation notice in system prompt
- [x] End-to-end validated against a real 1M-token CC session: `ancestors` query succeeded with `minimalSystemPrompt: true` + `maxPromptTokens: 950000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)